### PR TITLE
Update wd-security to 2.1.1.55

### DIFF
--- a/Casks/wd-security.rb
+++ b/Casks/wd-security.rb
@@ -1,6 +1,6 @@
 cask 'wd-security' do
-  version '2.1.1.55'
-  sha256 '28628a2011e92c59c3517aa2213134ee20443e1827a996275bae8ade595cd6b6'
+  version '2.1.1.61'
+  sha256 'b6744537b81a4bfb27c23413e457ddf74864220734a59a0df5ee0e48d90de8f5'
 
   url "http://downloads.wdc.com/wdapp/WD_Security_Standalone_Installer_Mac_#{version.dots_to_underscores}.zip"
   name 'WD Security'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.