### PR TITLE
Update nvidia-web-driver to 387.10.10.10.35.106

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,10 +1,10 @@
 cask 'nvidia-web-driver' do
-  version '387.10.10.10.30.107'
-  sha256 'c5b269f03851774a1d6b3620c627a1d23065546a1cda03ad94f82b81fbeadf01'
+  version '387.10.10.10.35.106'
+  sha256 'bb60b4bff4eb918de2b872eaa59e061a92d8306e305cbd70300246ebff1a0b24'
 
   url "https://images.nvidia.com/mac/pkg/#{version.major}/WebDriver-#{version}.pkg"
   appcast 'https://gfe.nvidia.com/mac-update',
-          checkpoint: 'ae5b5890c15199ae84aca0adc2ce94e71512c0bfa71c9adeb56c6d00f473fe6b'
+          checkpoint: 'edc6378eaeb3ce9e078257799b856cff55990a34eedabc126ba76fc93ccfe26f'
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/Download/index.aspx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.