### PR TITLE
Update lmsclients-squeezeplay to 7.8.0r1101

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -1,11 +1,11 @@
 cask 'lmsclients-squeezeplay' do
-  version '7.8.0r1072'
-  sha256 'daecd41fad9d6edbbab9bde6fbc5ddef0fbb80909b99a13def8b1f233c003ff6'
+  version '7.8.0r1101'
+  sha256 '85b7f4fdab8efd3200a96085e81acde60c98ac9e91369d85426ab3994c134891'
 
   # downloads.sourceforge.net/lmsclients was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lmsclients/SqueezePlay-x86_64-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/lmsclients/rss?path=/squeezeplay/osx',
-          checkpoint: 'fa360234322c4439d2a6420788694b33a910ba3f533a46256ca0776d0a282f00'
+          checkpoint: '51229f27fee5e62d838bac07c4bb8a8028b27780fb7406f17ab356c2805d6171'
   name 'Logitech LMS SqueezePlay Client'
   homepage 'http://forums.slimdevices.com/showthread.php?96328-ANNOUNCE-SqueezePlay-for-Mac-OSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.