### PR TITLE
Update wacom-intuos-tablet to 6.3.30-2

### DIFF
--- a/Casks/wacom-intuos-tablet.rb
+++ b/Casks/wacom-intuos-tablet.rb
@@ -1,6 +1,6 @@
 cask 'wacom-intuos-tablet' do
-  version '6.3.29-6'
-  sha256 '2eb19a2fe0e636c951ca1d9ee66abb50f63378ff2562970c6b6f31b71633c941'
+  version '6.3.30-2'
+  sha256 'b0381061a1c503a8597daac92f0816c5b7be7ad8f0274c872f8536bc409c4ed4'
 
   url "http://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   name 'Wacom Intuos 4/5/Pro Tablet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.