### PR TITLE
Upgrade DisplayLink Installer.app to v4.3 BETA 6

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,6 +1,6 @@
 cask 'displaylink' do
-  version '4.1,1085'
-  sha256 '14b6186fc3a9b202d0fbafde742e8d357e60427b9a6f1f6ee52ebbd478e729d0'
+  version '4.3,1184'
+  sha256 '259cd718b65cda090e369a538ae8be8727da14e210a3702e5e133603a95736ff'
 
   url "http://www.displaylink.com/downloads/file?id=#{version.after_comma}",
       data:  {


### PR DESCRIPTION
A few months back a macos update broke displaylink functionality. Their fix is still in BETA:
More info here: http://www.displaylink.com/downloads/macos

After making all changes to the cask:

- [x] `brew cask audit --download displaylink` is error-free.
- [x] `brew cask style --fix displaylink` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

