### PR TITLE
Update synology-photo-station-uploader to 1.4.4-091

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,6 +1,6 @@
 cask 'synology-photo-station-uploader' do
-  version '1.4.3-087'
-  sha256 'dcc1b8d3e145d85df955914b842c624d759089b5d1023fb264fdedf39b448e6e'
+  version '1.4.4-091'
+  sha256 'f25e009170387720291570d3acfef048d9ee05477c5a0b207df965ddf924d4cb'
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
   name 'Synology Photo Station Uploader'

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -8,5 +8,9 @@ cask 'synology-photo-station-uploader' do
 
   pkg "PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.pkg"
 
-  uninstall pkgutil: 'com.synology.photostationuploader.installer'
+  uninstall pkgutil:   'com.synology.photostationuploader.installer',
+            launchctl: [
+                         'com.synology.PhotoUploaderShellApp',
+                         'com.synology.SynoSIMBL_RefreshFinder',
+                       ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.