### PR TITLE
Update nordic-nrf5x-command-line-tools to 53406.21.45235762

### DIFF
--- a/Casks/nordic-nrf5x-command-line-tools.rb
+++ b/Casks/nordic-nrf5x-command-line-tools.rb
@@ -1,5 +1,5 @@
 cask 'nordic-nrf5x-command-line-tools' do
-  version '53406.21.3166817'
+  version '53406.21.45235762'
   sha256 '95ad0aba8f9db50ad30b4a3963772648c69b34a79a27a580ff85f0248ac11e5c'
 
   url "https://www.nordicsemi.com/eng/nordic/download_resource/#{version.major}/#{version.minor}/#{version.patch}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.