### PR TITLE
Update blackvue-viewer to 1.22

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.20,74331'
-  sha256 '82784dcb6c006998a06acb94bd4eab8030958a70f3fbff290793c7722d65a58b'
+  version '1.22'
+  sha256 '8122159060497cf1f4f6639fbcf9696cb4acceab7018fa1afa53259a2898c98b'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   name 'BlackVue Viewer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.