### PR TITLE
Update segger-jlink to 6.32i

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.32g'
-  sha256 'c54ba1ae94f3a605e547deefb0d7a747787cbb2e229a79428a64029445e9a89c'
+  version '6.32i'
+  sha256 '5ee5f95a1737a49dafe2bdd37aef5491426c178c7c909bae4f03a1a0acf76520'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.