### PR TITLE
Add content-manager-assistant

### DIFF
--- a/Casks/content-manager-assistant.rb
+++ b/Casks/content-manager-assistant.rb
@@ -1,0 +1,27 @@
+cask 'content-manager-assistant' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://cma.dl.playstation.net/cma/module/mac/CMAInstaller.pkg'
+  name 'Content Manager Assistant for PlayStation®'
+  homepage 'http://cma.dl.playstation.net/cma/mac/en/index.html'
+
+  pkg 'CMAInstaller.pkg'
+
+  uninstall quit:    [
+                       'jp.co.scei.ContentManagerAssistant',
+                       'jp.co.scei.ContentManagerAssistant.Watcher',
+                     ],
+            pkgutil: 'jp.co.scei.ContentManagerAssistant.installer'
+
+  zap trash: [
+               '~/Documents/PS Vita',
+               '~/Library/Application Support/Sony Corporation/Content Manager Assistant',
+               '~/Library/Caches/jp.co.scei.ContentManagerAssistant.Downloader',
+               '~/Library/Preferences/jp.co.scei.ContentManagerAssistant.plist',
+             ]
+
+  caveats do
+    reboot
+  end
+end


### PR DESCRIPTION
Not sure if `for PlayStation` should be included in cask filename. Its pretty general name without it.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
