### PR TITLE
Update segger-jlink to 6.34b

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.34a'
-  sha256 '107239de450bc65ae3fdc8b2e46326fd2acca938a6b1285b99a8631c8784cc94'
+  version '6.34b'
+  sha256 '73f6f2d939b4ff17350bacd1cb977afc142e5b2cd1665ee802461b160e77724a'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.