### PR TITLE
Update Fitbit Connect to v2.0.2.7241

### DIFF
--- a/Casks/fitbit-connect.rb
+++ b/Casks/fitbit-connect.rb
@@ -1,6 +1,6 @@
 cask 'fitbit-connect' do
-  version '2.0.2.7189-2018-02-07'
-  sha256 'edb30f13a34bb83bede269014ae151e4d3f5ea0f127142b2195a3c7acf33338d'
+  version '2.0.2.7241-2018-07-25'
+  sha256 '464ccce6b3ea13c1836dd74e315270816fe15cb6e19276be1b189ba99ad5d346'
 
   url "https://cache.fitbit.com/FitbitConnect/FitbitConnect-v#{version}.dmg"
   name 'Fitbit Connect'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] Updated [version-checksum](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)

`brew cask style --fix fitbit-connect` return the following error:

```
==> Installing or updating 'rubocop-cask' gem
Error: Unable to resolve dependency: user requested 'did_you_mean (= 1.0.0)'
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:231:in `search_for'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:283:in `block in sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `each'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `sort_by'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `with_index'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:52:in `block in sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:69:in `with_no_such_dependency_error_handling'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:51:in `sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:165:in `initial_state'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:106:in `start_resolution'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:64:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:42:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:188:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/request_set.rb:385:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/request_set.rb:397:in `resolve_current'
/Library/Ruby/Site/2.3.0/rubygems.rb:245:in `finish_resolve'
/Library/Ruby/Site/2.3.0/rubygems/rdoc.rb:15:in `<top (required)>'
/Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Library/Ruby/Site/2.3.0/rubygems/commands/install_command.rb:280:in `load_hooks'
/Library/Ruby/Site/2.3.0/rubygems/commands/install_command.rb:156:in `execute'
/usr/local/Homebrew/Library/Homebrew/utils.rb:230:in `install_gem!'
/usr/local/Homebrew/Library/Homebrew/utils.rb:238:in `install_gem_setup_path!'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:21:in `block in install_rubocop'
/usr/local/Homebrew/Library/Homebrew/utils.rb:407:in `capture_stderr'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:19:in `install_rubocop'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:11:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/abstract_command.rb:33:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:90:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:156:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:121:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:7:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:87:in `<main>'
```
