### PR TITLE
Update netgear-switch-discovery-tool to 1.2.101

### DIFF
--- a/Casks/netgear-switch-discovery-tool.rb
+++ b/Casks/netgear-switch-discovery-tool.rb
@@ -6,7 +6,7 @@ cask 'netgear-switch-discovery-tool' do
   name 'NETGEAR Switch Discovery Tool'
   homepage 'https://www.netgear.com/support/download/'
 
-  container nested: "NetgearSDT-V#{version}/NetgearSDT-V#{version}.dmg"
+  container nested: "NetgearSDT-V#{version}-Mac/NetgearSDT-V#{version}.dmg"
 
   app 'NETGEAR Switch Discovery Tool.app'
 end

--- a/Casks/netgear-switch-discovery-tool.rb
+++ b/Casks/netgear-switch-discovery-tool.rb
@@ -1,8 +1,8 @@
 cask 'netgear-switch-discovery-tool' do
-  version '1.1.115'
-  sha256 'e2988b8ebb58e8953885a46c4f9e94ba6ebebfc34b93cc902fbc44540d798bf8'
+  version '1.2.101'
+  sha256 'f0ed6cd9eb2f3ec3bf6e27bc4279777640c26143d9e6c635ec7b3d18dcd66042'
 
-  url "https://www.downloads.netgear.com/files/GDC/NetgearSDT-V#{version}.zip"
+  url "https://www.downloads.netgear.com/files/GDC/NSDT/NetgearSDT-V#{version}-Mac.zip"
   name 'NETGEAR Switch Discovery Tool'
   homepage 'https://www.netgear.com/support/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.