### PR TITLE
Update oki-postscript-drivers to 2.0.2

### DIFF
--- a/Casks/oki-postscript-drivers.rb
+++ b/Casks/oki-postscript-drivers.rb
@@ -2,9 +2,9 @@ cask 'oki-postscript-drivers' do
   version '2.0.2'
   sha256 'b8d5058744d93d040433eb841dcd2481848e61b659e84da459785310044857fa'
 
-  url 'http://belgium.oki.com/Includes/Pages/FileDownload.aspx?id=tcm:125-152412'
+  url 'http://www.oki.com/printing/download/OKI_MXMLion_DPS_eu_A1_3_35555.dmg'
   name 'OKI MC860 PS Driver for OSX'
-  homepage 'http://belgium.oki.com/support/printer/printer-drivers/detail.aspx?prodid=tcm:125-4613&driverid=tcm:125-152412-16'
+  homepage 'https://www.oki.com/ge/printing/support/drivers-and-utilities/?id=46251801FZ01&tab=drivers-and-utilities&productCategory=colour-multifunction&sku=43967004&lang=ac2'
 
   pkg 'OKI PostScript Driver.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.