### PR TITLE
Update canon-imagerunner-printer-driver-ufrii to 10.16.00

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,11 +1,13 @@
 cask 'canon-imagerunner-printer-driver-ufrii' do
-  version '10.15.00'
-  sha256 '819181ebc0becfdb2cab2fb4809c957ae88ce1991a29b9ce1a45572e68420b17'
+  version '10.16.00'
+  sha256 '1040965f7c583be2156ce3d76325b1e1435e50ea002a2ebf8072afad9145a74f'
 
   url "https://downloads.canon.com/bisg2018/drivers/mac/UFRII_v#{version}_Mac.zip"
   appcast 'https://www.usa.canon.com/internet/PA_NWSupport/driversDownloads?model=15802&os=MACOS_V10_12&type=DS&lang=English'
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
+
+  container nested: "UFRII_v#{version}_Mac.dmg"
 
   pkg 'UFRII_LT_LIPS_LX_Installer.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.