### PR TITLE
Update lg-onscreen-control to 3.06_patch2_08-Jun

### DIFF
--- a/Casks/lg-onscreen-control.rb
+++ b/Casks/lg-onscreen-control.rb
@@ -1,8 +1,9 @@
 cask 'lg-onscreen-control' do
-  version '2.93_Patch1,20150116943155:66KiTUDNOklaNSrpHYo6QA'
-  sha256 'a261ec486635b00ee6ff4a0d4feb88143889d14957652fd5e94c50204d9c49a1'
+  version '3.06_patch2_08-Jun'
+  sha256 'f4b02aaadb1f96e0e0ed9eeb6a9eced79c9bb0e52a833fd56a4134417569ad25'
 
-  url "https://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=#{version.after_comma.before_colon}&what=MANUAL&fromSystem=LG.COM&fileId=#{version.after_colon}&ORIGINAL_NAME_b1_a1=Mac_OSC_#{version.before_comma}.zip"
+  # lge.com was verified as official when first introduced to the cask
+  url 'http://gscs-b2c.lge.com/downloadFile?fileId=llBVD1dzcCzDocSnIyUkwg'
   name 'LG OnScreen Control'
   homepage 'https://www.lg.com/us/support/monitors'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.