### PR TITLE
Update brother-p-touch-update-software to 1.5.0

### DIFF
--- a/Casks/brother-p-touch-update-software.rb
+++ b/Casks/brother-p-touch-update-software.rb
@@ -1,8 +1,8 @@
 cask 'brother-p-touch-update-software' do
-  version '1.4.7'
-  sha256 'e2f098562e23d85bc446e288a73f1b4e45482bb553f6fee0b889b06aee9907ce'
+  version '1.5.0'
+  sha256 '37ddaf7bec64b1d51608aff15d8bc6b72cf9bcfc205cb7f90e55cba8a2b5ac0f'
 
-  url "https://download.brother.com/welcome/dlfp100352/pum#{version.no_dots}x12all.dmg"
+  url "https://download.brother.com/welcome/dlfp100565/pum#{version.no_dots}x13all.dmg"
   name 'Brother P-touch Update Software'
   homepage 'http://support.brother.com/g/b/downloadhowto.aspx?c=us&lang=en&prod=lpql720nweus&os=10017&dlid=dlfp100352_000&flang=178&type3=10183'
 

--- a/Casks/brother-p-touch-update-software.rb
+++ b/Casks/brother-p-touch-update-software.rb
@@ -8,5 +8,8 @@ cask 'brother-p-touch-update-software' do
 
   pkg 'BrotherPtUpdateSoftware.pkg'
 
-  uninstall pkgutil: 'com.brother.brotherptdriver.BrotherPtUpdateSoftware'
+  uninstall pkgutil: [
+                       'com.brother.brotherptdriver.BrotherPtUpdateSoftware',
+                       'com.Brother.Brotherdriver.BrotherPtUpdateSoftware',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.