### PR TITLE
Update synology-surveillance-station-client to 1.2.0-0553

### DIFF
--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -1,24 +1,23 @@
 cask 'synology-surveillance-station-client' do
-  version '1.1.4-0406'
-  sha256 '1e4809ae9c58e25d564393b8a19fc153954fbdcd157eaeeaa8eb982e04b91feb'
+  version '1.2.0-0553'
+  sha256 '08d28121d019556aa4cfdf4e395e7ac9cdc987be765c5f92d570fe500b01406c'
 
   url "https://global.download.synology.com/download/Tools/SurveillanceStationClient/#{version}/Mac/Synology%20Surveillance%20Station%20Client-#{version}.dmg"
+  appcast 'https://www.synology.com/releaseNote/SurveillanceStationClient'
   name 'Synology Surveillance Station Client'
   homepage 'https://www.synology.com/surveillance/'
 
-  pkg 'Surveillance Station Client.pkg'
+  pkg 'Install Surveillance Station Client.pkg'
 
-  uninstall launchctl: 'com.synology.ssc.launch.agent',
+  uninstall launchctl: 'com.synology.svsclient-SurveillanceStationClient',
             delete:    '/Applications/Surveillance Station Client.app',
             pkgutil:   [
                          'com.synology.svsclient-Live-View',
                          'com.synology.svsclient-Recording',
                          'com.synology.svsclient-Timeline',
-                         'svsclient',
-                         'SurveillanceStationClient',
+                         'com.synology.svsclient-SurveillanceStationClient',
                        ],
             quit:      [
-                         'svsclient',
-                         'SurveillanceStationClient',
+                         'com.synology.svsclient-SurveillanceStationClient',
                        ]
 end

--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -11,13 +11,11 @@ cask 'synology-surveillance-station-client' do
 
   uninstall launchctl: 'com.synology.svsclient-SurveillanceStationClient',
             delete:    '/Applications/Surveillance Station Client.app',
+            quit:      'com.synology.svsclient-SurveillanceStationClient',
             pkgutil:   [
                          'com.synology.svsclient-Live-View',
                          'com.synology.svsclient-Recording',
                          'com.synology.svsclient-Timeline',
                          'com.synology.svsclient-SurveillanceStationClient',
                        ],
-            quit:      [
-                         'com.synology.svsclient-SurveillanceStationClient',
-                       ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.