### PR TITLE
Update silicon-labs-vcp-driver to 5.0.6

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,6 +1,6 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0.5'
-  sha256 '2c22f2441d642351091a1de8d4fda84340cbf8cc13624fedb588415610cf0248'
+  version '5.0.6'
+  sha256 'c4decacb776bab3a6c40de0c572faf0e556f3682fd0327e3d97663916a86f0ba'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -8,7 +8,7 @@ cask 'silicon-labs-vcp-driver' do
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'
 
-  container nested: 'SiLabsUSBDriverDisk.dmg'
+  container nested: 'Mac_OSX_VCP_Driver/SiLabsUSBDriverDisk.dmg'
 
   pkg 'Silicon Labs VCP Driver.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.