### PR TITLE
Update logitech-control-center to 3.9.7.56

### DIFF
--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -1,6 +1,6 @@
 cask 'logitech-control-center' do
-  version '3.9.6.241'
-  sha256 '599f2fdbd8051a4bfb61ba0430a2eb3204b8a29badb9a22b8ac0ad9f44fd3b5f'
+  version '3.9.7.56'
+  sha256 '9be3127908a90653e851a7f07a25c00d6e76677c216537c979e7a4c804a4447c'
 
   url "https://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
   name 'Logitech Control Center'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.