### PR TITLE
Update lightkey.rb

### DIFF
--- a/Casks/lightkey.rb
+++ b/Casks/lightkey.rb
@@ -7,6 +7,8 @@ cask 'lightkey' do
   name 'Lightkey'
   homepage 'http://lightkeyapp.com/'
 
+  depends_on macos: '>= :high_sierra'
+
   pkg 'LightkeyInstaller.pkg'
 
   uninstall pkgutil: [


### PR DESCRIPTION
add missing system requirement. version 2.4 was the last to require 10.11, now it requires 10.13
