### PR TITLE
Rename sony-remoteplay to sony-ps4-remote-play

### DIFF
--- a/Casks/sony-ps4-remote-play.rb
+++ b/Casks/sony-ps4-remote-play.rb
@@ -1,4 +1,4 @@
-cask 'sony-remoteplay' do
+cask 'sony-ps4-remote-play' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
Not having "PS4" in the name makes this cask very difficult to find.

Also, changed it to `remote-play` based on what's suggested by *generate_cask_token* script.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
