### PR TITLE
Update synology-cloud-station-backup to 4.2.8-4421

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -1,8 +1,9 @@
 cask 'synology-cloud-station-backup' do
-  version '4.2.5-4396'
-  sha256 '420784b2defc921f4072f4f2577b413a4e6462cac74a4cc298e5109b0ccf5a57'
+  version '4.2.8-4421'
+  sha256 '70cbe39729bc841d6e9d8aedd1d90b6c1058630ed53f0d8f272fd6b88f42cc91'
 
   url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
+  appcast 'https://archive.synology.com/download/Tools/CloudStationBackup/'
   name 'Synology Cloud Station Backup'
   homepage 'https://www.synology.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.