### PR TITLE
Update reolink-client to 3.5.1.53

### DIFF
--- a/Casks/reolink-client.rb
+++ b/Casks/reolink-client.rb
@@ -1,6 +1,6 @@
 cask 'reolink-client' do
-  version '3.4.2.49'
-  sha256 '9a0f882ca429cf0fef4162aa51d6de751aac674670fedcb346a1a0b3a85ae30e'
+  version '3.5.1.53'
+  sha256 '70d114e02ec772d3cae83f4a31b826b26ad86354811abef929593b63bc7638a4'
 
   # s3.amazonaws.com/reolink-storage was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/reolink-storage/website/client/Mac-ReolinkClient.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.