### PR TITLE
Add 'ftdi-vcp-driver' dependency to 'suunto-dm5'

### DIFF
--- a/Casks/suunto-dm5.rb
+++ b/Casks/suunto-dm5.rb
@@ -6,6 +6,7 @@ cask 'suunto-dm5' do
   name 'Suunto DM5'
   homepage 'http://dm5.movescount.com/'
 
+  depends_on cask: 'ftdi-vcp-driver'
   depends_on cask: 'mono-mdk'
 
   app 'SuuntoDM5.app'


### PR DESCRIPTION
The FTDIUSBSerialDriver is required to run the Suunto DM5 application.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
