### PR TITLE
Update logitech-unifying to 1.3.375

### DIFF
--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -12,6 +12,6 @@ cask 'logitech-unifying' do
                        'com.Logitech.Unifying Software.pkg',
                        'com.Logitech.Updater.pkg',
                      ],
-             delete: '/Applications/Utilities/Logitech Unifying Software.app',
-             quit:   'com.logitech.unifying.assistant'
+            delete:  '/Applications/Utilities/Logitech Unifying Software.app',
+            quit:    'com.logitech.unifying.assistant'
 end

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -1,6 +1,6 @@
 cask 'logitech-unifying' do
-  version '1.2.359'
-  sha256 'e6fd9c1b536033f3346b32c391bd58587ea9f549cab7839cf8a1dbc62a739825'
+  version '1.3.375'
+  sha256 '915116757a33d3d9c5be706d12718824b4082b3e495f2a77a3ffc70db5956666'
 
   url "https://www.logitech.com/pub/controldevices/unifying/unifying#{version}_mac.zip"
   name 'Logitech Unifying Software'

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -11,7 +11,7 @@ cask 'logitech-unifying' do
   uninstall pkgutil: [
                        'com.Logitech.Unifying Software.pkg',
                        'com.Logitech.Updater.pkg',
-                     ],                  
+                     ],
              delete: '/Applications/Utilities/Logitech Unifying Software.app',
-             quit: 'com.logitech.unifying.assistant'
+             quit:   'com.logitech.unifying.assistant'
 end

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -11,5 +11,7 @@ cask 'logitech-unifying' do
   uninstall pkgutil: [
                        'com.Logitech.Unifying Software.pkg',
                        'com.Logitech.Updater.pkg',
-                     ]
+                     ],                  
+             delete: '/Applications/Utilities/Logitech Unifying Software.app',
+             quit: 'com.logitech.unifying.assistant'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.