### PR TITLE
Update steelseries-engine to 3.12.13

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask 'steelseries-engine' do
-  version '3.12.12'
-  sha256 'ab80799396df0faf9dd57e3b72aae56f1777f473df03c13f09ed402b773fad77'
+  version '3.12.13'
+  sha256 '340b30317343e8c4ebc5c04bcd0f780d4aca0ac4c3c5b28e7bdd7df75c3f6fe1'
 
   # steelseriescdn.com was verified as official when first introduced to the cask
   url "https://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.