### PR TITLE
Update brother-p-touch-editor to 5.1.110

### DIFF
--- a/Casks/brother-p-touch-editor.rb
+++ b/Casks/brother-p-touch-editor.rb
@@ -1,8 +1,8 @@
 cask 'brother-p-touch-editor' do
-  version '5.1.109'
-  sha256 'a1ecebc4688e5d44e5ca761501387f77c092ae96ed4dbc6fe5c6ce242fdf76af'
+  version '5.1.110'
+  sha256 '237ef13b68a96d686e99e78214a75ce3aec5bbb7b4073f49c34cd494057c0081'
 
-  url "https://download.brother.com/pub/com/ptouch-su/editor/pem#{version.no_dots}x12us.dmg"
+  url "https://download.brother.com/pub/com/ptouch-su/editor/pem#{version.no_dots}x14us.dmg"
   name 'Brother P-Touch Editor'
   homepage 'http://www.brother.com/product/dev/label/editor/index.htm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.