### PR TITLE
Update synologyassistant to 6.2-23733

### DIFF
--- a/Casks/synologyassistant.rb
+++ b/Casks/synologyassistant.rb
@@ -1,8 +1,9 @@
 cask 'synologyassistant' do
-  version '6.1-15030'
-  sha256 '78bc5981227f124ae9bc8419d404f5fd6671928a1fb73318c30a2277570be738'
+  version '6.2-23733'
+  sha256 '6b12b68e24c4db8e37e40807ec3eed94148c6047fa28c5cb53fa79c5da61d064'
 
   url "https://global.download.synology.com/download/Tools/Assistant/#{version}/Mac/synology-assistant-#{version}.dmg"
+  appcast 'https://archive.synology.com/download/Tools/Assistant/'
   name 'Synology Assistant'
   homepage 'https://www.synology.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.