### PR TITLE
Update garmin-express to 6.8.0.0

### DIFF
--- a/Casks/garmin-express.rb
+++ b/Casks/garmin-express.rb
@@ -1,6 +1,6 @@
 cask 'garmin-express' do
-  version :latest
-  sha256 :no_check
+  version '6.8.0.0'
+  sha256 '7b50dd98e218fe6c6c52240dbe907df1a5681537d3f696cbba5ba60e1e48f924'
 
   url 'https://download.garmin.com/omt/express/GarminExpress.dmg'
   name 'Garmin Express'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.