### PR TITLE
Update nordic-nrf5x-command-line-tools to 53406.22.23260625

### DIFF
--- a/Casks/nordic-nrf5x-command-line-tools.rb
+++ b/Casks/nordic-nrf5x-command-line-tools.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf5x-command-line-tools' do
-  version '53406.21.3166817'
-  sha256 '95ad0aba8f9db50ad30b4a3963772648c69b34a79a27a580ff85f0248ac11e5c'
+  version '53406.22.23260625'
+  sha256 'bbdbcb5ce028b56c0927727f6872707cbba7d53358d160d68c5b1da7e27f2dd2'
 
   url "https://www.nordicsemi.com/eng/nordic/download_resource/#{version.major}/#{version.minor}/#{version.patch}"
   name 'nRF5x Command Line Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.