### PR TITLE
Evolv EScribe Suite 2_SP18

### DIFF
--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -1,6 +1,6 @@
 cask 'evolv-escribe-suite' do
-  version '2_SP15_1'
-  sha256 '2d2b636ae9c7ec001667f98ae585f48affb301209a1a7398421efb9bad342adf'
+  version '2_SP18'
+  sha256 '51d824ce95ea80a6c3d8c075b4b523b58cdbb2f1265d8dbfb3c5c72a22555cf6'
 
   url "https://downloads.evolvapor.com/SetupEScribe#{version}_INT.pkg"
   name 'EScribe Suite'


### PR DESCRIPTION
EScribe Suite 2.0 SP18

--- EScribe ---
When you double-click an .ecig file, it now opens a Settings Installer (similar to the Theme Installer).
--- EScribe Suite ---
Fixed MacOS Mojave compatibility.
Minor bug fixes.

EScribe Suite 2.0 SP17

--- DNA Go (firmware 1.1 SP37) ---
Improved the LED response to lock/unlock.
--- DNA 250 Color (firmware 1.1 SP35) ---
Improved the deep sleep behavior.
--- Theme Designer ---
Fixed a crash on Linux when moving controls.
--- EScribe Suite ---
DNA Go support.
Minor bug fixes.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.