### PR TITLE
Update displaylink to 5.0.1

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -7,10 +7,9 @@ cask 'displaylink' do
   #  sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
   #  container type: :zip
   #  container nested: 'DisplayLink Installer 75598.dmg'
-  # elsif MacOS.version == :yosemite
-  #  version '3.1.1,1252'
-  #  sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'
-  #  container nested: "DisplayLink USB Graphics Software for Mac OS X #{version.before_comma}.dmg"
+  elsif MacOS.version == :yosemite
+    version '3.1.1,1252'
+    sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'
   elsif MacOS.version <= :high_sierra
     version '4.3.1,1251'
     sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -2,11 +2,10 @@ cask 'displaylink' do
   if MacOS.version <= :lion
     version '2.2,121'
     sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
-  # elsif MacOS.version <= :mavericks
-  #  version '2.6,707'
-  #  sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
-  #  container type: :zip
-  #  container nested: 'DisplayLink Installer 75598.dmg'
+  elsif MacOS.version <= :mavericks
+    version '2.6,707'
+    sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
+    container type: :zip
   elsif MacOS.version == :yosemite
     version '3.1.1,1252'
     sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -2,7 +2,6 @@ cask 'displaylink' do
   if MacOS.version <= :lion
     version '2.2,121'
     sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
-  #  container nested: "DisplayLink_Mac_#{version.before_comma}.dmg"
   # elsif MacOS.version <= :mavericks
   #  version '2.6,707'
   #  sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
@@ -15,11 +14,9 @@ cask 'displaylink' do
   elsif MacOS.version <= :high_sierra
     version '4.3.1,1251'
     sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'
-    # container nested: "DisplayLink USB Graphics Software for Mac OS X and macOS #{version.before_comma}.dmg"
   else
     version '5.0.1,1257'
     sha256 'deb7ad535987bdaf1358f2a806b8f66a5caa5b7c7843e9029b33e30cf8435b4d'
-    # container nested: "DisplayLink USB Graphics Software for macOS #{version.before_comma}.dmg"
   end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",
@@ -30,9 +27,6 @@ cask 'displaylink' do
       using: :post
   name 'DisplayLink USB Graphics Software'
   homepage 'https://www.displaylink.com/'
-
-  # TODO: test if this is required.
-  # container nested: "DisplayLink Installer #{version.before_comma}.dmg"
 
   pkg 'DisplayLink Software Installer.pkg'
 

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,6 +1,27 @@
 cask 'displaylink' do
-  version '4.1.11,1085'
-  sha256 '14b6186fc3a9b202d0fbafde742e8d357e60427b9a6f1f6ee52ebbd478e729d0'
+  if MacOS.version <= :lion
+    version '2.2,121'
+    sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
+    #container nested: "DisplayLink_Mac_#{version.before_comma}.dmg"
+  #elsif MacOS.version <= :mavericks
+  #  version '2.6,707'
+  #  sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
+  #  container type: :zip
+  #  container nested: 'DisplayLink Installer 75598.dmg'
+
+  #elsif MacOS.version == :yosemite
+  #  version '3.1.1,1252'
+  #  sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'
+  #  container nested: "DisplayLink USB Graphics Software for Mac OS X #{version.before_comma}.dmg"
+  elsif MacOS.version <= :high_sierra
+    version '4.3.1,1251'
+    sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'
+    #container nested: "DisplayLink USB Graphics Software for Mac OS X and macOS #{version.before_comma}.dmg"
+  #else
+  #  version '5.0.1,1257'
+  #  sha256 'deb7ad535987bdaf1358f2a806b8f66a5caa5b7c7843e9029b33e30cf8435b4d'
+  #  container nested: "DisplayLink USB Graphics Software for macOS #{version.before_comma}.dmg"
+  end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",
       data:  {
@@ -10,8 +31,6 @@ cask 'displaylink' do
       using: :post
   name 'DisplayLink USB Graphics Software'
   homepage 'https://www.displaylink.com/'
-
-  container nested: "DisplayLink Installer #{version.before_comma}.dmg"
 
   pkg 'DisplayLink Software Installer.pkg'
 

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -2,7 +2,6 @@ cask 'displaylink' do
   if MacOS.version <= :mavericks
     version '2.6,707'
     sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
-    container type: :zip
   elsif MacOS.version <= :yosemite
     version '3.1.1,1252'
     sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,12 +1,9 @@
 cask 'displaylink' do
-  if MacOS.version <= :lion
-    version '2.2,121'
-    sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
-  elsif MacOS.version <= :mavericks
+  if MacOS.version <= :mavericks
     version '2.6,707'
     sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
     container type: :zip
-  elsif MacOS.version == :yosemite
+  elsif MacOS.version <= :yosemite
     version '3.1.1,1252'
     sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'
   elsif MacOS.version <= :high_sierra

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -2,25 +2,24 @@ cask 'displaylink' do
   if MacOS.version <= :lion
     version '2.2,121'
     sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
-    #container nested: "DisplayLink_Mac_#{version.before_comma}.dmg"
-  #elsif MacOS.version <= :mavericks
+  #  container nested: "DisplayLink_Mac_#{version.before_comma}.dmg"
+  # elsif MacOS.version <= :mavericks
   #  version '2.6,707'
   #  sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
   #  container type: :zip
   #  container nested: 'DisplayLink Installer 75598.dmg'
-
-  #elsif MacOS.version == :yosemite
+  # elsif MacOS.version == :yosemite
   #  version '3.1.1,1252'
   #  sha256 'cc4e73357841463509f1430520eec04792cbfbf9a2a564ea17d5cc78774372d0'
   #  container nested: "DisplayLink USB Graphics Software for Mac OS X #{version.before_comma}.dmg"
   elsif MacOS.version <= :high_sierra
     version '4.3.1,1251'
     sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'
-    #container nested: "DisplayLink USB Graphics Software for Mac OS X and macOS #{version.before_comma}.dmg"
-  #else
-  #  version '5.0.1,1257'
-  #  sha256 'deb7ad535987bdaf1358f2a806b8f66a5caa5b7c7843e9029b33e30cf8435b4d'
-  #  container nested: "DisplayLink USB Graphics Software for macOS #{version.before_comma}.dmg"
+    # container nested: "DisplayLink USB Graphics Software for Mac OS X and macOS #{version.before_comma}.dmg"
+  else
+    version '5.0.1,1257'
+    sha256 'deb7ad535987bdaf1358f2a806b8f66a5caa5b7c7843e9029b33e30cf8435b4d'
+    # container nested: "DisplayLink USB Graphics Software for macOS #{version.before_comma}.dmg"
   end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",
@@ -31,6 +30,9 @@ cask 'displaylink' do
       using: :post
   name 'DisplayLink USB Graphics Software'
   homepage 'https://www.displaylink.com/'
+
+  # TODO: test if this is required.
+  # container nested: "DisplayLink Installer #{version.before_comma}.dmg"
 
   pkg 'DisplayLink Software Installer.pkg'
 

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -22,6 +22,8 @@ cask 'displaylink' do
   name 'DisplayLink USB Graphics Software'
   homepage 'https://www.displaylink.com/'
 
+  depends_on macos: '>= :mountain_lion'
+
   pkg 'DisplayLink Software Installer.pkg'
 
   uninstall pkgutil:   [
@@ -35,6 +37,7 @@ cask 'displaylink' do
             #              'com.displaylink.dlusbncm'
             #            ],
             launchctl: [
+                         '73YQY62QM3.com.displaylink.DisplayLinkAPServer',
                          'com.displaylink.useragent-prelogin',
                          'com.displaylink.useragent',
                          'com.displaylink.displaylinkmanager',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I have two questions regarding updating this cask. 
- I removed the `container nested:` stanza in order to be able to install the cask.
The following is a snippet of the `brew cask install --verbose` output (under `macOS 10.12.6`).
```
==> Purging files for version 4.3.1,1251 of Cask displaylink
Error: No such file or directory @ rb_sysopen - /var/folders/ql/qf_jlfws1yvcdzwwwywpqvx00000gn/T/d20181104-2309-1lz3xga/DisplayLink Installer 4.3.1.dmg
```
The `Mavericks` installer is downloaded as a `zip` instead of a `dmg` as is the case for the others.
The cask is able to install with or without `container: :zip`, but I left it in for completeness.

Why was `container nested:` required in the past, but does it result in an error now?
What is the use case of `container: :zip`, since it does not influence the behaviour.

- A fix of this cask exists for macOS 10.14, but only for 2018 MacBooks. See [DisplayLink](https://www.displaylink.com/downloads/macos).
Is it possible to add such a hardware requirement?

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256