### PR TITLE
Update ubiquiti-unifi-controller to 5.9.29

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -3,6 +3,7 @@ cask 'ubiquiti-unifi-controller' do
   sha256 'e028f9103e44c62d401caa9b74dfd0b049ae7d8532a0580f43f39dc8e789faf9'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
+  appcast 'https://www.ubnt.com/download/unifi/'
   name 'UniFi Controller'
   homepage 'https://www.ubnt.com/download/unifi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.