### PR TITLE
Update blackvue-viewer to 1.27,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.26,74331'
-  sha256 '54d9ea9e99b1367bd44b362c18e31ef4065ddab8a737bbd3ca7cec4a6b9ae88b'
+  version '1.27,74331'
+  sha256 '5742cdc8b9a4e85ad50ec5f0881d0c9bb1c78dd58eeb85e35975e9d146bdcf76'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   name 'BlackVue Viewer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.