### PR TITLE
Update steelseries-engine to 3.13.2

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask 'steelseries-engine' do
-  version '3.13.0'
-  sha256 'd1b7e39a9507168ec3a87ccee2b5c25e91a50ff0c78dd649590e4587f04c1d4b'
+  version '3.13.2'
+  sha256 '6ddb4ecbe724158205c57dfcef48df065ab72012f48e27b0a67250e1c049b8b4'
 
   # steelseriescdn.com was verified as official when first introduced to the cask
   url "https://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).