### PR TITLE
Add nvidia-cuda 9.0.176 for Sierra

### DIFF
--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -1,12 +1,17 @@
 cask 'nvidia-cuda' do
-  version '10.0.130'
-  sha256 '4f76261ed46d0d08a597117b8cacba58824b8bb1e1d852745658ac873aae5c8e'
+  if MacOS.version <= :sierra
+    version '9.0.176'
+    sha256 '8fad950098337d2611d64617ca9f62c319d97c5e882b8368ed196e994bdaf225'
+  elsif MacOS.version <= :high_sierra
+    version '10.0.130'
+    sha256 '4f76261ed46d0d08a597117b8cacba58824b8bb1e1d852745658ac873aae5c8e'
+  end
 
   url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac"
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '<= :high_sierra'
 
   installer script: {
                       executable: 'CUDAMacOSXInstaller.app/Contents/MacOS/CUDAMacOSXInstaller',

--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -2,7 +2,7 @@ cask 'nvidia-cuda' do
   if MacOS.version <= :sierra
     version '9.0.176'
     sha256 '8fad950098337d2611d64617ca9f62c319d97c5e882b8368ed196e994bdaf225'
-  elsif MacOS.version <= :high_sierra
+  else
     version '10.0.130'
     sha256 '4f76261ed46d0d08a597117b8cacba58824b8bb1e1d852745658ac873aae5c8e'
   end

--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -1,12 +1,12 @@
 cask 'nvidia-cuda' do
-  version '9.2.64'
-  sha256 'af7bd0aa4c889974a31365ca40005e21651959387e8392d3a29c2f90dd187f40'
+  version '10.0.130'
+  sha256 '4f76261ed46d0d08a597117b8cacba58824b8bb1e1d852745658ac873aae5c8e'
 
   url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac"
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   installer script: {
                       executable: 'CUDAMacOSXInstaller.app/Contents/MacOS/CUDAMacOSXInstaller',

--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -11,6 +11,7 @@ cask 'nvidia-cuda' do
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'
 
+  # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
   depends_on macos: '<= :high_sierra'
 
   installer script: {


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Add support for Sierra and fix the `depends_on` stanza. [According to Nvidia](https://devtalk.nvidia.com/default/topic/1042279/cuda-setup-and-installation/cuda-10-and-macos-10-14/), Mojave is not supported with version `10.0.130`.