### PR TITLE
Update segger-ozone to 2.60g

### DIFF
--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -1,6 +1,6 @@
 cask 'segger-ozone' do
-  version '2.60f'
-  sha256 '17e9f60ac15a64465a6a60d4f9b04d57ecec93a9e210791efd6e576c03eb21c2'
+  version '2.60g'
+  sha256 'f1e40c116a3811a480645d866fbd6c867057d5d287d0ae6f8c5b2fc7ef92d3c4'
 
   url "https://www.segger.com/downloads/jlink/Ozone_MacOSX_V#{version.no_dots}_Universal.pkg"
   name 'Ozone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.