### PR TITLE
Add roland-quad-capture-usb-driver 1.5.4

### DIFF
--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -21,16 +21,32 @@ cask 'roland-quad-capture-usb-driver' do
   pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
 
   uninstall pkgutil:   'jp.co.roland.QuadCapture.*',
-            launchctl: 'jp.co.roland.RDUSB012FSetupd',
+            launchctl: [
+                         'jp.co.roland.RDUSB0000Setupd',
+                         'jp.co.roland.RDUSB012FSetupd',
+                       ],
             quit:      'QUAD-CAPTURE Control Panel',
-            kext:      'jp.co.roland.RDUSB012FDev',
+            kext:      [
+                         'jp.co.roland.RDUSB0000Dev',
+                         'jp.co.roland.RDUSB012FDev',
+                       ],
             script:    [
-                         executable: "#{staged_path}/QuadCaptureUSBDriver/Uninstaller.app/Contents/MacOS/Uninstaller",
+                         executable: "#{staged_path}/QuadCaptureUSBDriver/Uninstaller.app/Contents/Resources/Script",
                          sudo:       true,
                        ],
             delete:    [
+                         '~/Library/Preferences/jp.co.roland.RDUSB012F.cpl.plist',
                          '/Applications/QUAD-CAPTURE Control Panel.app',
                          '/Applications/Roland/QUAD-CAPTURE Driver',
+                         '/Library/Audio/MIDI Drivers/RDUSB0000Midi.plugin',
+                         '/Library/Audio/MIDI Drivers/RDUSB012FMidi.plugin',
+                         '/Library/Application Support/RolandDrv',
+                         '/Library/Preferences/jp_co_roland_RDUSB0000Dev.pref.plist',
+                         '/Library/Preferences/jp_co_roland_RDUSB012FDev.pref.plist',
+                         '/Library/PreferencePanes/RDUSB012FPref.prefPane',
+                         '/Library/PreferencePanes/RDUSB0000Pref.prefPane',
+                         '/Library/StartupItems/RDUSB012FStartup',
+                         '/Library/StartupItems/RDUSB0000Startup',
                        ]
 
   caveats do

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -1,0 +1,49 @@
+cask 'roland-quad-capture-usb-driver' do
+  if MacOS.version <= :yosemite
+    version '1.5.2,10'
+    sha256 'da575f4b3874e0042fddffb4462f4521019ceaa3f44942f64bce099b426cf2d1'
+    url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+  elsif MacOS.version <= :sierra
+    version '1.5.3,12'
+    sha256 '712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770'
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+  else
+    version '1.5.4,13'
+    sha256 'd3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117'
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+  end
+
+  name 'Roland Quad-Capture USB Driver'
+  homepage 'https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/'
+
+  depends_on macos: '>= :yosemite'
+
+  pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
+
+  uninstall pkgutil:   [
+                         "jp.co.roland.QuadCapture.app.10#{version.after_colon}.pkg",
+                         "jp.co.roland.QuadCapture.kext.10#{version.after_colon}.pkg",
+                         "jp.co.roland.QuadCapture.midi.10#{version.after_colon}.pkg",
+                         "jp.co.roland.QuadCapture.start.10#{version.after_colon}.pkg",
+                       ],
+            launchctl: [
+                         'jp.co.roland.RDUSB012FSetupd',
+                       ],
+            quit:        'QUAD-CAPTURE Control Panel',
+            kext:      [
+                         'jp.co.roland.RDUSB012FDev',
+                       ],
+            script:    [
+                         executable: "#{staged_path}/QuadCaptureUSBDriver/Uninstaller.app/Contents/MacOS/Uninstaller",
+                         sudo:       true,
+                       ],
+            delete:    [
+                        '/Applications/QUAD-CAPTURE Control Panel.app',
+                        '/Applications/Roland/QUAD-CAPTURE Driver',
+                       ]
+
+  caveats do
+    license 'https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/53d8a307-a8ae-4f9b-9a59-a1adb8c67012/'
+    reboot
+  end
+end

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -29,7 +29,7 @@ cask 'roland-quad-capture-usb-driver' do
             launchctl: [
                          'jp.co.roland.RDUSB012FSetupd',
                        ],
-            quit:        'QUAD-CAPTURE Control Panel',
+            quit:      'QUAD-CAPTURE Control Panel',
             kext:      [
                          'jp.co.roland.RDUSB012FDev',
                        ],
@@ -38,8 +38,8 @@ cask 'roland-quad-capture-usb-driver' do
                          sudo:       true,
                        ],
             delete:    [
-                        '/Applications/QUAD-CAPTURE Control Panel.app',
-                        '/Applications/Roland/QUAD-CAPTURE Driver',
+                         '/Applications/QUAD-CAPTURE Control Panel.app',
+                         '/Applications/Roland/QUAD-CAPTURE Driver',
                        ]
 
   caveats do

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -2,15 +2,15 @@ cask 'roland-quad-capture-usb-driver' do
   if MacOS.version <= :yosemite
     version '1.5.2,10:24c21855-3c40-469c-a40c-7647a52bf022'
     sha256 'da575f4b3874e0042fddffb4462f4521019ceaa3f44942f64bce099b426cf2d1'
-    url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+    url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
   elsif MacOS.version <= :sierra
     version '1.5.3,12:199aee04-dd6b-4a9c-9945-ba9ffb295113'
     sha256 '712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770'
-    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
   else
     version '1.5.4,13:53d8a307-a8ae-4f9b-9a59-a1adb8c67012'
     sha256 'd3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117'
-    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
   end
 
   name 'Roland Quad-Capture USB Driver'
@@ -18,13 +18,13 @@ cask 'roland-quad-capture-usb-driver' do
 
   depends_on macos: '>= :yosemite'
 
-  pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
+  pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
 
   uninstall pkgutil:   [
-                         "jp.co.roland.QuadCapture.app.10#{version.after_colon}.pkg",
-                         "jp.co.roland.QuadCapture.kext.10#{version.after_colon}.pkg",
-                         "jp.co.roland.QuadCapture.midi.10#{version.after_colon}.pkg",
-                         "jp.co.roland.QuadCapture.start.10#{version.after_colon}.pkg",
+                         "jp.co.roland.QuadCapture.app.10#{version.after_comma.before_colon}.pkg",
+                         "jp.co.roland.QuadCapture.kext.10#{version.after_comma.before_colon}.pkg",
+                         "jp.co.roland.QuadCapture.midi.10#{version.after_comma.before_colon}.pkg",
+                         "jp.co.roland.QuadCapture.start.10#{version.after_comma.before_colon}.pkg",
                        ],
             launchctl: [
                          'jp.co.roland.RDUSB012FSetupd',

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -1,14 +1,14 @@
 cask 'roland-quad-capture-usb-driver' do
   if MacOS.version <= :yosemite
-    version '1.5.2,10'
+    version '1.5.2,10:24c21855-3c40-469c-a40c-7647a52bf022'
     sha256 'da575f4b3874e0042fddffb4462f4521019ceaa3f44942f64bce099b426cf2d1'
     url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
   elsif MacOS.version <= :sierra
-    version '1.5.3,12'
+    version '1.5.3,12:199aee04-dd6b-4a9c-9945-ba9ffb295113'
     sha256 '712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770'
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
   else
-    version '1.5.4,13'
+    version '1.5.4,13:53d8a307-a8ae-4f9b-9a59-a1adb8c67012'
     sha256 'd3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117'
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
   end
@@ -43,7 +43,7 @@ cask 'roland-quad-capture-usb-driver' do
                        ]
 
   caveats do
-    license 'https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/53d8a307-a8ae-4f9b-9a59-a1adb8c67012/'
+    license "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/#{version.after_colon}/"
     reboot
   end
 end

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -20,19 +20,10 @@ cask 'roland-quad-capture-usb-driver' do
 
   pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
 
-  uninstall pkgutil:   [
-                         "jp.co.roland.QuadCapture.app.10#{version.after_comma.before_colon}.pkg",
-                         "jp.co.roland.QuadCapture.kext.10#{version.after_comma.before_colon}.pkg",
-                         "jp.co.roland.QuadCapture.midi.10#{version.after_comma.before_colon}.pkg",
-                         "jp.co.roland.QuadCapture.start.10#{version.after_comma.before_colon}.pkg",
-                       ],
-            launchctl: [
-                         'jp.co.roland.RDUSB012FSetupd',
-                       ],
+  uninstall pkgutil:   'jp.co.roland.QuadCapture.*',
+            launchctl: 'jp.co.roland.RDUSB012FSetupd',
             quit:      'QUAD-CAPTURE Control Panel',
-            kext:      [
-                         'jp.co.roland.RDUSB012FDev',
-                       ],
+            kext:      'jp.co.roland.RDUSB012FDev',
             script:    [
                          executable: "#{staged_path}/QuadCaptureUSBDriver/Uninstaller.app/Contents/MacOS/Uninstaller",
                          sudo:       true,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Currently the `uninstall` stanza does not completely work successfully. The `script` key calls an uninstaller, which is started, but requires the user to press a button to continue. After the uninstaller GUI is finished, the only button left to press is to restart the system. This is undesirable. Is there a way to start the uninstaller without using the GUI?

The `caveat` stanza calls a `license` URL, but this URL is actually only for version `1.5.4` of the driver. The other versions have their license at a different URL. Is there a construct for a conditional `license` method?