### PR TITLE
Add nvidia-web-driver 378.05.05.25f11 for Sierra

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,13 +1,29 @@
 cask 'nvidia-web-driver' do
-  version '387.10.10.10.40.108'
-  sha256 '090cd232ea8ed7bdd51450174dfceda81d4b4ad675f3a9122bc9c137af9ad49f'
+  if MacOS.version <= :yosemite
+    version '346.02.03f14'
+    sha256 '21df2785257c58b940168b4d4ff73e32f71e9f7e28ed879bf0d605e4abc74aef'
+  elsif MacOS.version <= :el_capitan
+    version '346.03.15f16'
+    sha256 'f0c1a23a262ba6db35f1d7a0da39e7b7648805d63d65be20af33e582cc7050bc'
+  elsif MacOS.version <= :sierra
+    version '378.05.05.25f11'
+    sha256 '7230bf6ef1681b34d7acabeea54979139a2421f47fd28100f104923eaab9370e'
+  else
+    version '387.10.10.10.40.108'
+    sha256 '090cd232ea8ed7bdd51450174dfceda81d4b4ad675f3a9122bc9c137af9ad49f'
+  end
 
   url "https://images.nvidia.com/mac/pkg/#{version.major}/WebDriver-#{version}.pkg"
   appcast 'https://gfe.nvidia.com/mac-update'
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/Download/index.aspx'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: [
+                      :yosemite,
+                      :el_capitan,
+                      :sierra,
+                      :high_sierra,
+                    ]
 
   pkg "WebDriver-#{version}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
