### PR TITLE
Update nordic-nrf-connect.rb

### DIFF
--- a/Casks/nordic-nrf-connect.rb
+++ b/Casks/nordic-nrf-connect.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-connect' do
-  version '56320.17.8035140.108238'
-  sha256 '689c828042799b40750e3a07728c463116babb477e7e07f814a8e410edca276c'
+  version '2.6.0'
+  sha256 '?'
 
   url "https://www.nordicsemi.com/eng/nordic/download_resource/#{version.dots_to_slashes}"
   appcast 'https://www.nordicsemi.com/eng/nordic/Products/nRF-Connect-for-Desktop/nRF-Connect-macOS/56320'


### PR DESCRIPTION
ok this is a placeholder and not ready to merge.

i am unable to figure this out in a timely manner and would appreciate some help here.

brew cask install nordic-nrf-connect currently fails

the newest version is now 2.6.0 but i am unable to determine a working download link from this site:

https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop/Download#infotabs