### PR TITLE
Add apogee-symphony-mkii 3.1

### DIFF
--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -1,0 +1,36 @@
+cask 'apogee-symphony-mkii' do
+  if MacOS.version <= :mavericks
+    version '2.0'
+    sha256 'd905990be51cb27d4849978c6d54986cde27cf5364e9eb3b3843751f4f4a25f8'
+  else
+    version '3.1'
+    sha256 'b65fbadca751721b22517faf8fc1a72b1c8b7b0a102fd515efe1e265c9917aa7'
+  end
+
+  url "http://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
+  name 'Apogee Symphony I/O MkII'
+  homepage 'http://www.apogeedigital.com/support/symphony-io-mk-ii'
+
+  depends_on macos: '>= :mavericks'
+
+  pkg 'Symphony IO MkII Installer.pkg'
+
+  uninstall pkgutil:   [
+                         'com.apogee.pkg.ApogeeSymphonyIO2TAudioPlugin',
+                         'com.apogee.pkg.SIOC2TBFirmwareUpdater',
+                         'com.apogee.pkg.kextApogeeSymphonyIO2T',
+                         'com.apogeedigital.SymphonyControl',
+                         'com.apogeedigital.SymphonyHelper',
+                       ],
+            launchctl: [
+                         'com.SymphonyHelper.plist',
+                       ],
+            script:    [
+                         executable: "#{staged_path}/Symphony IO MkII Uninstaller.app/Contents/Resources/SymphonyIOMkIIUnInstall.sh",
+                         sudo:       true,
+                       ]
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -7,7 +7,7 @@ cask 'apogee-symphony-mkii' do
     sha256 'b65fbadca751721b22517faf8fc1a72b1c8b7b0a102fd515efe1e265c9917aa7'
   end
 
-  url "http://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
+  url "https://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
   name 'Apogee Symphony I/O MkII'
   homepage 'http://www.apogeedigital.com/support/symphony-io-mk-ii'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

I intentionally did not use a wildcard `*` for the `com.apogee.pkg` entries in `pkgutil`. The reason is that other Apogee drivers also use this prefix and this could potentially lead to uninstalling packages belonging to those different drivers.