### PR TITLE
Add casio-exam-mode-unlocker 1.00

### DIFF
--- a/Casks/casio-exam-mode-unlocker.rb
+++ b/Casks/casio-exam-mode-unlocker.rb
@@ -1,0 +1,17 @@
+cask 'casio-exam-mode-unlocker' do
+  version '1.00,5'
+  sha256 '716f475829af3e737d5782552a49022aeba8622e177604ce5ccd5e0e70448af2'
+
+  url "https://edu.casio.com/education/support_software/dl/exam_mode_unlocker/exammodeunlocker_inst_#{version.before_comma.no_dots}_#{version.after_comma}.zip"
+  name 'Casio Exam Mode Unlocker'
+  homepage 'https://edu.casio.com/education/support_software/'
+
+  depends_on macos: [
+                      :yosemite,
+                      :el_capitan,
+                      :sierra,
+                      :high_sierra,
+                    ]
+
+  app 'Exam Mode Unlocker.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

It is only an `app`, but since it concerns hardware (a calculator) I thought this would be a better place than `homebrew-cask`. Also because another Casio cask is located in this repository (`casio-screen-receiver.rb`).