### PR TITLE
Update garmin-express to 6.10.1.0

### DIFF
--- a/Casks/garmin-express.rb
+++ b/Casks/garmin-express.rb
@@ -1,6 +1,6 @@
 cask 'garmin-express' do
-  version :latest
-  sha256 :no_check
+  version '6.10.1.0'
+  sha256 '7ba0c219430c674350230757cbfcebd3958b7b7d8aafcfb244b4c7e986210860'
 
   url 'https://download.garmin.com/omt/express/GarminExpress.dmg'
   name 'Garmin Express'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.