### PR TITLE
Add elgato-video-capture 2.0

### DIFF
--- a/Casks/elgato-video-capture.rb
+++ b/Casks/elgato-video-capture.rb
@@ -1,0 +1,20 @@
+cask 'elgato-video-capture' do
+  if MacOS.version <= :yosemite
+    version '1.1.5,7253'
+    sha256 'e75fa022944d662d58f8715b0a53340d48d76a7bdc8a020e1ac981bbd317eee5'
+    # http://files.elgato.com/evcdownloads/support/evc_115_7253.dmg
+  else
+    version '2.0,8701'
+    sha256 'dbb6b64143cf5954bdef1b9543b627bf482fe857cbeece0738bb3ca029fb47b9'
+    # https://update.elgato.com/mac/video-capture-update/download.php?build=8701
+    # https://edge.elgato.com/video-capture/macos/2.0/final/Elgato Video Capture 2.0 (8701).dmg
+  end
+
+  url "https://update.elgato.com/mac/video-capture-update/download.php?build=#{version.after_comma}"
+  name 'Elgato Video Capture'
+  homepage 'https://www.elgato.com/en/video-capture/support'
+
+  depends_on macos: '>= :snow_leopard'
+
+  app 'Elgato Video Capture.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

Various versions of the software can be retrieved using the `url` and `build` parm. However, the resulting `url` contains spaces and therefore the `audit` step fails:
```
audit for elgato-video-capture: failed
 - download not possible: Download failed on Cask 'elgato-video-capture' with message: bad URI(is not URI?): https://edge.elgato.com/video-capture/macos/2.0/final/Elgato Video Capture 2.0 (8701).dmg
Error: audit failed for casks: elgato-video-capture
```
Is there a way to solve this problem? Otherwise I will have to use the resulting `url` instead. That would work, but makes maintenance more cumbersome.