### PR TITLE
Update elgato-stream-deck to 3.3.1.8372

### DIFF
--- a/Casks/elgato-stream-deck.rb
+++ b/Casks/elgato-stream-deck.rb
@@ -1,6 +1,6 @@
 cask 'elgato-stream-deck' do
-  version '3.3.0.8359'
-  sha256 '9401b4f755b83ce50a5958a05290cedfc88c5451cc5a1c17dbcc092dc60b6409'
+  version '3.3.1.8372'
+  sha256 'c70930e88ea4f8079327e585577cafc7ec194d0f446cf9801ea906b6883272f3'
 
   url "https://edge.elgato.com/egc/macos/sd/Stream_Deck_#{version}.pkg"
   name 'Elgato Stream Deck'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.