### PR TITLE
Update blackvue-viewer to 1.29,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.28,74331'
-  sha256 '99aeaf10667d354239e306fdaf2fab65ed011cfde1236b613239a31b44159608'
+  version '1.29,74331'
+  sha256 'a6b44eab2b7678a2645822671030ee90890936e4b371c0e2643e8fe962352d07'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.