### PR TITLE
Update kiibohd-configurator to 1.0.0

### DIFF
--- a/Casks/kiibohd-configurator.rb
+++ b/Casks/kiibohd-configurator.rb
@@ -1,6 +1,6 @@
 cask 'kiibohd-configurator' do
-  version '0.4.1'
-  sha256 '71cd04f9b660e5ebd06c3647e153975078f8d808078e98f59caa6833631beee3'
+  version '1.0.0'
+  sha256 '8591e8fd0a18f2a0a5c0a1022c126ddc5c5715ec8f5a7af3d9e756883e715e39'
 
   # github.com/kiibohd/configurator was verified as official when first introduced to the cask
   url "https://github.com/kiibohd/configurator/releases/download/v#{version}/kiibohd-configurator-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.