### PR TITLE
Add roland-octa-capture-usb-driver 1.5.4 appcast and zap

### DIFF
--- a/Casks/roland-octa-capture-usb-driver.rb
+++ b/Casks/roland-octa-capture-usb-driver.rb
@@ -53,7 +53,7 @@ cask 'roland-octa-capture-usb-driver' do
                '/Library/Preferences/jp_co_roland_RDUSB0120Dev.pref.plist',
                '~/Library/Preferences/jp.co.roland.RDUSB0120.cpl.plist',
                '~/Library/Saved Application State/jp.co.roland.RDUSB0120.Uninstaller.savedState',
-            ]
+             ]
 
   caveats do
     license "https://www.roland.com/us/support/by_product/octa-capture/updates_drivers/#{version.after_colon}"

--- a/Casks/roland-octa-capture-usb-driver.rb
+++ b/Casks/roland-octa-capture-usb-driver.rb
@@ -13,8 +13,9 @@ cask 'roland-octa-capture-usb-driver' do
     url "https://static.roland.com/assets/media/tgz/octa_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
   end
 
+  appcast 'https://www.roland.com/us/support/by_product/octa-capture/updates_drivers'
   name 'Roland Octa-Capture USB Driver'
-  homepage 'https://www.roland.com/us/support/by_product/octa-capture/updates_drivers/'
+  homepage 'https://www.roland.com/us/products/octa-capture/'
 
   depends_on macos: '>= :yosemite'
 
@@ -35,22 +36,27 @@ cask 'roland-octa-capture-usb-driver' do
                          sudo:       true,
                        ],
             delete:    [
-                         '~/Library/Preferences/jp.co.roland.RDUSB0120.cpl.plist',
                          '/Applications/OCTA-CAPTURE Control Panel.app',
                          '/Applications/Roland/OCTA-CAPTURE Driver',
                          '/Library/Audio/MIDI Drivers/RDUSB0000Midi.plugin',
                          '/Library/Audio/MIDI Drivers/RDUSB0120Midi.plugin',
                          '/Library/Application Support/RolandDrv',
-                         '/Library/Preferences/jp_co_roland_RDUSB0000Dev.pref.plist',
-                         '/Library/Preferences/jp_co_roland_RDUSB0120Dev.pref.plist',
-                         '/Library/PreferencePanes/RDUSB0000Pref.prefPane',
-                         '/Library/PreferencePanes/RDUSB0120Pref.prefPane',
                          '/Library/StartupItems/RDUSB0000Startup',
                          '/Library/StartupItems/RDUSB0120Startup',
-                       ]
+                       ],
+            rmdir:     '/Applications/Roland'
+
+  zap trash: [
+               '/Library/PreferencePanes/RDUSB0000Pref.prefPane',
+               '/Library/PreferencePanes/RDUSB0120Pref.prefPane',
+               '/Library/Preferences/jp_co_roland_RDUSB0000Dev.pref.plist',
+               '/Library/Preferences/jp_co_roland_RDUSB0120Dev.pref.plist',
+               '~/Library/Preferences/jp.co.roland.RDUSB0120.cpl.plist',
+               '~/Library/Saved Application State/jp.co.roland.RDUSB0120.Uninstaller.savedState',
+            ]
 
   caveats do
-    license "https://www.roland.com/us/support/by_product/octa-capture/updates_drivers/#{version.after_colon}/"
+    license "https://www.roland.com/us/support/by_product/octa-capture/updates_drivers/#{version.after_colon}"
     reboot
   end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).