### PR TITLE
Update 3dconnexion to 10.6.1 and add appcast, uninstall, zap and caveats

### DIFF
--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -7,6 +7,8 @@ cask '3dconnexion' do
   name '3Dconnexion'
   homepage 'https://www.3dconnexion.com/'
 
+  depends_on macos: '>= :yosemite'
+
   pkg 'Install 3Dconnexion software.pkg'
 
   uninstall pkgutil:   'com.3dconnexion.*',

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -3,10 +3,47 @@ cask '3dconnexion' do
   sha256 '8060b6fbad9a3f1fe4e3c693e708f875c5cce3159948423ce414bda56434c9b3'
 
   url "https://www.3dconnexion.com/index.php?eID=sdl&ext=tx_iccsoftware&oid=#{version.after_comma}&filename=3DxWareMac_v#{version}.dmg"
+  appcast 'https://www.3dconnexion.com/service/drivers.html'
   name '3Dconnexion'
-  homepage 'https://www.3dconnexion.com/service/drivers.html'
+  homepage 'https://www.3dconnexion.com/'
 
   pkg 'Install 3Dconnexion software.pkg'
 
-  uninstall pkgutil: 'com.3dconnexion.*'
+  uninstall script:    [
+                         executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
+                         sudo:       true,
+                       ]
+  #uninstall #pkgutil:   'com.3dconnexion.*',
+            #launchctl: 'com.3dconnexion.nlserverIPalias',
+            #quit:      'com.3dconnexion.*',
+            #signal: [
+                      #['TERM', 'com.3dconnexion.driver'],
+                      #['QUIT', 'com.3dconnexion.driver'],
+                      #['INT',  'com.3dconnexion.driver'],
+                      #['HUP',  'com.3dconnexion.driver'],
+                      #['KILL', 'com.3dconnexion.driver'],
+                    #],
+            #kext:      'com.3dconnexion.driver', # TODO: (kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
+            # exists: /Applications/3Dconnexion/Uninstall\ 3Dconnexion\ Driver.app/Contents/Resources/rm3dcx
+            #executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
+            #,
+            #delete:    [
+            #             '/Applications/3Dconnexion',
+            #             '/Library/Extensions/3Dconnexion.kext',
+            #             '/Library/Frameworks/3DconnexionClient.framework',
+            #           ],
+            #rmdir:     '/Applications/3Dconnexion'
+
+  zap trash: [
+               '/Library/Application Support/3Dconnexion', # TODO: check if entire dir is removed.
+               '/Library/LaunchDaemons/com.3dconnexion.nlserverIPalias.plist',
+               '/Library/PreferencePanes/3Dconnexion.prefPane',
+               '~/Library/Logs/3Dconnexion',
+               '~/Library/Preferences/3Dconnexion',
+               '~/Library/Saved Application State/com.3dconnexion.*.savedState',
+             ]
+
+  caveats do
+    reboot
+  end
 end

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -9,13 +9,9 @@ cask '3dconnexion' do
 
   pkg 'Install 3Dconnexion software.pkg'
 
-  uninstall script:    [
-                         executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
-                         sudo:       true,
-                       ]
-  #uninstall #pkgutil:   'com.3dconnexion.*',
-            #launchctl: 'com.3dconnexion.nlserverIPalias',
-            #quit:      'com.3dconnexion.*',
+  uninstall pkgutil:   'com.3dconnexion.*',
+            launchctl: 'com.3dconnexion.nlserverIPalias',
+            quit:      'com.3dconnexion.*',
             #signal: [
                       #['TERM', 'com.3dconnexion.driver'],
                       #['QUIT', 'com.3dconnexion.driver'],
@@ -24,18 +20,19 @@ cask '3dconnexion' do
                       #['KILL', 'com.3dconnexion.driver'],
                     #],
             #kext:      'com.3dconnexion.driver', # TODO: (kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
-            # exists: /Applications/3Dconnexion/Uninstall\ 3Dconnexion\ Driver.app/Contents/Resources/rm3dcx
-            #executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
-            #,
-            #delete:    [
-            #             '/Applications/3Dconnexion',
-            #             '/Library/Extensions/3Dconnexion.kext',
-            #             '/Library/Frameworks/3DconnexionClient.framework',
-            #           ],
-            #rmdir:     '/Applications/3Dconnexion'
+            script:    [
+                         executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
+                         sudo:       true,
+                       ],
+            delete:    [
+                         '/Applications/3Dconnexion',
+                         '/Library/Extensions/3Dconnexion.kext',
+                         '/Library/Frameworks/3DconnexionClient.framework',
+                       ],
+            rmdir:     '/Applications/3Dconnexion'
 
   zap trash: [
-               '/Library/Application Support/3Dconnexion', # TODO: check if entire dir is removed.
+               '/Library/Application Support/3Dconnexion', #TODO: check if entire dir is removed.
                '/Library/LaunchDaemons/com.3dconnexion.nlserverIPalias.plist',
                '/Library/PreferencePanes/3Dconnexion.prefPane',
                '~/Library/Logs/3Dconnexion',

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -19,7 +19,7 @@ cask '3dconnexion' do
                       #['HUP',  'com.3dconnexion.driver'],
                       #['KILL', 'com.3dconnexion.driver'],
                     #],
-            #kext:      'com.3dconnexion.driver', # TODO: (kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
+            kext:      'com.3dconnexion.driver', # TODO: (kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
             script:    [
                          executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
                          sudo:       true,
@@ -32,11 +32,12 @@ cask '3dconnexion' do
             rmdir:     '/Applications/3Dconnexion'
 
   zap trash: [
-               '/Library/Application Support/3Dconnexion', #TODO: check if entire dir is removed.
+               '/Library/Application Support/3Dconnexion',
                '/Library/LaunchDaemons/com.3dconnexion.nlserverIPalias.plist',
                '/Library/PreferencePanes/3Dconnexion.prefPane',
                '~/Library/Logs/3Dconnexion',
                '~/Library/Preferences/3Dconnexion',
+               '~/Library/Preferences/com.3dconnexion.*.plist',
                '~/Library/Saved Application State/com.3dconnexion.*.savedState',
              ]
 

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -20,11 +20,11 @@ cask '3dconnexion' do
                          sudo:       true,
                        ],
             delete:    [
-                         "#{appdir}/3Dconnexion",
+                         '/Applications/3Dconnexion',
                          '/Library/Extensions/3Dconnexion.kext',
                          '/Library/Frameworks/3DconnexionClient.framework',
                        ],
-            rmdir:     "#{appdir}/3Dconnexion"
+            rmdir:     '/Applications/3Dconnexion'
 
   zap trash: [
                '/Library/Application Support/3Dconnexion',

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -20,11 +20,11 @@ cask '3dconnexion' do
                          sudo:       true,
                        ],
             delete:    [
-                         '/Applications/3Dconnexion',
+                         "#{appdir}/3Dconnexion",
                          '/Library/Extensions/3Dconnexion.kext',
                          '/Library/Frameworks/3DconnexionClient.framework',
                        ],
-            rmdir:     '/Applications/3Dconnexion'
+            rmdir:     "#{appdir}/3Dconnexion"
 
   zap trash: [
                '/Library/Application Support/3Dconnexion',

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -13,7 +13,10 @@ cask '3dconnexion' do
 
   uninstall pkgutil:   'com.3dconnexion.*',
             launchctl: 'com.3dconnexion.nlserverIPalias',
-            quit:      'com.3dconnexion.*',
+            quit:      [
+                         'com.3Dconnexion.3DxUpdater',
+                         'com.3dconnexion.*',
+                       ],
             # kext:      'com.3dconnexion.driver', # Fails to unload kext (classes have instances) when executing `brew zap`.
             script:    [
                          executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
@@ -23,8 +26,7 @@ cask '3dconnexion' do
                          '/Applications/3Dconnexion',
                          '/Library/Extensions/3Dconnexion.kext',
                          '/Library/Frameworks/3DconnexionClient.framework',
-                       ],
-            rmdir:     '/Applications/3Dconnexion'
+                       ]
 
   zap trash: [
                '/Library/Application Support/3Dconnexion',

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -1,6 +1,6 @@
 cask '3dconnexion' do
-  version '10-6-0_r2876,dac9287b-1f2a-859f-1428-5bd9fb06fe4a'
-  sha256 '8060b6fbad9a3f1fe4e3c693e708f875c5cce3159948423ce414bda56434c9b3'
+  version '10-6-1_r2897,a8111ac7-d575-9772-1dc6-5c37a3a6c64c'
+  sha256 '3b037438bf220ea30d2d9b4bdaf9f512e3d3a2e2f205841f85ef9a1a81b54d91'
 
   url "https://www.3dconnexion.com/index.php?eID=sdl&ext=tx_iccsoftware&oid=#{version.after_comma}&filename=3DxWareMac_v#{version}.dmg"
   appcast 'https://www.3dconnexion.com/service/drivers.html'

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -17,7 +17,6 @@ cask '3dconnexion' do
                          'com.3Dconnexion.3DxUpdater',
                          'com.3dconnexion.*',
                        ],
-            # kext:      'com.3dconnexion.driver', # Fails to unload kext (classes have instances) when executing `brew zap`.
             script:    [
                          executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
                          sudo:       true,

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -12,7 +12,7 @@ cask '3dconnexion' do
   uninstall pkgutil:   'com.3dconnexion.*',
             launchctl: 'com.3dconnexion.nlserverIPalias',
             quit:      'com.3dconnexion.*',
-            kext:      'com.3dconnexion.driver',
+            # kext:      'com.3dconnexion.driver', # Fails to unload kext (classes have instances) when executing `brew zap`.
             script:    [
                          executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
                          sudo:       true,

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -12,14 +12,7 @@ cask '3dconnexion' do
   uninstall pkgutil:   'com.3dconnexion.*',
             launchctl: 'com.3dconnexion.nlserverIPalias',
             quit:      'com.3dconnexion.*',
-            #signal: [
-                      #['TERM', 'com.3dconnexion.driver'],
-                      #['QUIT', 'com.3dconnexion.driver'],
-                      #['INT',  'com.3dconnexion.driver'],
-                      #['HUP',  'com.3dconnexion.driver'],
-                      #['KILL', 'com.3dconnexion.driver'],
-                    #],
-            kext:      'com.3dconnexion.driver', # TODO: (kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
+            kext:      'com.3dconnexion.driver',
             script:    [
                          executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
                          sudo:       true,


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Even though this cask installs a kext, when the `uninstall kext:` key is used, `brew uninstall` works as expected (and CI passes), but `brew zap` reports the following failure:
```
$ brew cask zap --verbose ./3dconnexion.rb
==> Implied "brew cask uninstall 3dconnexion"
==> Running uninstall process for 3dconnexion; your password may be necessary
==> Removing launchctl service com.3dconnexion.nlserverIPalias
Password:
==> Unloading kernel extension com.3dconnexion.driver
(kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
(kernel)     Kext com.3dconnexion.driver class ConnexionVirtualHID has 1 instance.
Failed to unload com.3dconnexion.driver - (libkern/kext) kext is in use or retained (cannot unload).
Error: Failure while executing; `/usr/bin/sudo -E -- /sbin/kextunload -b com.3dconnexion.driver` exited with 3. Here's the output:
(kernel) Can't unload kext com.3dconnexion.driver; classes have instances:
(kernel)     Kext com.3dconnexion.driver class ConnexionVirtualHID has 1 instance.
Failed to unload com.3dconnexion.driver - (libkern/kext) kext is in use or retained (cannot unload).
```
This fail is not caught in the CI flow, because it seems that `brew zap` is not tested.
For this reason, a comment inside the `uninstall kext:` key is added.