### PR TITLE
Update apogee-duet 2.5 uninstall and zap

### DIFF
--- a/Casks/apogee-duet.rb
+++ b/Casks/apogee-duet.rb
@@ -9,18 +9,48 @@ cask 'apogee-duet' do
 
   depends_on macos: '>= :mavericks'
 
-  app 'Duet USB Firmware Updater.app'
   pkg 'Duet Software Installer.pkg'
 
-  uninstall pkgutil:   'com.apogee.pkg.*',
+  uninstall pkgutil:   [
+                         'com.apogee.pkg.ApogeePopup',
+                         'com.apogee.pkg.ApogeeServices',
+                         'com.apogee.pkg.DuetUSB*',
+                         'com.apogee.pkg.Maestro2',
+                       ],
             launchctl: [
                          'com.ApogeePopup.plist',
                          'com.DuetUSBDaemon.plist',
                        ],
+            quit:      [
+                         'com.apogee.Apogee-Maestro-2',
+                         'com.apogee.Duet-USB-Firmware-Updater',
+                       ],
+            kext:      'com.apogeedigital.kext.ApogeeUSBDuetAudio',
             script:    [
                          executable: "#{staged_path}/Duet Uninstaller.app/Contents/Resources/DuetUSBUninstall.sh",
                          sudo:       true,
+                       ],
+            delete:    [
+                         '/Library/Application Support/Apogee/ApogeePopup.bundle',
+                         '/Library/Audio/Plug-Ins/HAL/Apogee/DuetUSB',
+                         '/Library/Extensions/DuetUSBOverideDriver.kext',
+                         '/Library/Frameworks/ApogeeServices.framework',
+                       ],
+            rmdir:     [
+                         '/Library/Application Support/Apogee',
+                         '/Library/Audio/Plug-Ins/HAL/Apogee',
                        ]
+
+  zap trash: [
+               '/Library/LaunchAgents/com.ApogeePopup.plist',
+               '/Library/LaunchDaemons/com.DuetUSBDaemon.plist',
+               '/Library/Preferences/com.apogee.productsInstalled.plist',
+               '~/Library/Caches/com.apogee.Apogee-Maestro-2',
+               '~/Library/Caches/com.apogee.ApogeePopup',
+               '~/Library/Preferences/com.apogee.Apogee-Maestro-2.plist',
+               '~/Library/Saved Application State/com.apogee.Apogee-Maestro-2.savedState',
+               '~/Library/Saved Application State/com.apogee.Duet-USB-Firmware-Updater.savedState',
+             ]
 
   caveats do
     reboot


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The `app` stanza is removed since the app is automatically installed into `/Applications/Utilities`. Currently the app is also installed in `/Applications`.

The `uninstall pkgutil` stanza is specified in detail, since the wildcard potentially removes files from other Apogee casks too (if installed).