### PR TITLE
Update apogee-symphony-mkii 3.1 uninstall and zap

### DIFF
--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -23,13 +23,30 @@ cask 'apogee-symphony-mkii' do
                          'com.apogeedigital.SymphonyControl',
                          'com.apogeedigital.SymphonyHelper',
                        ],
-            launchctl: [
-                         'com.SymphonyHelper.plist',
+            launchctl: 'com.SymphonyHelper.plist',
+            quit:      [
+                         'com.apogeedigital.Symphony-IO-Mk-II-Thunderbolt-Firmware-Updater',
+                         'com.apogeedigital.SymphonyControl',
+                         'com.apogeedigital.SymphonyHelper',
                        ],
+            kext:      'com.apogeedigital.kextSymphonyIO2T',
             script:    [
                          executable: "#{staged_path}/Symphony IO MkII Uninstaller.app/Contents/Resources/SymphonyIOMkIIUnInstall.sh",
                          sudo:       true,
-                       ]
+                       ],
+            delete:    [
+                         '/Library/Application Support/Apogee/Symphony Helper.app',
+                         '/Library/Audio/Plug-Ins/HAL/ApogeeSymphonyIO2T.driver',
+                         '/Library/Extensions/ApogeeSymphonyIO2T.kext',
+                       ],
+            rmdir:     '/Library/Application Support/Apogee'
+
+  zap trash: [
+               '/Library/LaunchAgents/com.SymphonyHelper.plist',
+               '~/Library/Preferences/com.apogeedigital.SymphonyControl.plist',
+               '~/Library/Saved Application State/com.apogeedigital.Symphony-IO-Mk-II-Thunderbolt-Firmware-Updater.savedState',
+               '~/Library/Saved Application State/com.apogeedigital.SymphonyControl.savedState',
+             ]
 
   caveats do
     reboot


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

A similar update to #724.