### PR TITLE
Update apogee-symphony 5.4 uninstall and zap

### DIFF
--- a/Casks/apogee-symphony.rb
+++ b/Casks/apogee-symphony.rb
@@ -15,24 +15,62 @@ cask 'apogee-symphony' do
 
   depends_on macos: '>= :mavericks'
 
-  app 'SymphonyIO Firmware Updater.app'
   pkg 'Symphony Software Installer.pkg'
 
   uninstall pkgutil:   [
                          'com.apogee.driver.Symphony64',
-                         'com.apogee.pkg.*',
+                         'com.apogee.pkg.ApogeePopup',
+                         'com.apogee.pkg.ApogeeServices',
+                         'com.apogee.pkg.Maestro.*',
+                         'com.apogee.pkg.Symphony.*',
                          'com.apogee.symphonySystem.*',
                        ],
             launchctl: [
                          'com.ApogeePopup.plist',
-                         'com.symphonyDaemon.plist',
                          'com.SymphonyIOUSBDaemon.plist',
+                         'com.symphonyDaemon.plist',
                          'com.usbApogeeDaemon.plist',
+                       ],
+            quit:      [
+                         'com.apogee.Apogee-Maestro-.*',
+                         'com.apogeedigital.ThunderBridge-Firmware-Updater',
+                       ],
+            signal:    ['TERM', 'com.apogee.SymphonyIO-Firmware-Updater'],
+            kext:      [
+                         'com.apogee.driver.ApogeeUSBSymphonyIOAudio',
+                         'com.apogeedigital.driver.Symphony64',
+                         'com.apogeedigital.driver.Symphony64ThunderBridge',
                        ],
             script:    [
                          executable: "#{staged_path}/Symphony System Uninstaller.app/Contents/Resources/SymphonyUnInstall.sh",
                          sudo:       true,
+                       ],
+            delete:    [
+                         '/Library/Application Support/Apogee/ApogeePopup.bundle',
+                         '/Library/Audio/Plug-Ins/HAL/Apogee/Symphony Systems',
+                         '/Library/Extensions/Symphony64.kext',
+                         '/Library/Extensions/Symphony64Thunderbridge.kext',
+                         '/Library/Extensions/SymphonyIOUSBOverideDriver.kext',
+                         '/Library/Frameworks/ApogeeServices.framework',
+                       ],
+            rmdir:     [
+                         '/Library/Application Support/Apogee',
+                         '/Library/Audio/Plug-Ins/HAL/Apogee',
                        ]
+
+  zap trash: [
+               '/Library/LaunchAgents/com.ApogeePopup.plist',
+               '/Library/LaunchDaemons/com.SymphonyDaemon.plist',
+               '/Library/LaunchDaemons/com.SymphonyIOUSBDaemon.plist',
+               '/Library/LaunchDaemons/com.usbApogeeDaemon.plist',
+               '/Library/Preferences/com.apogee.productsInstalled.plist',
+               '~/Library/Caches/com.apogee.Apogee-Maestro-2',
+               '~/Library/Caches/com.apogee.ApogeePopup',
+               '~/Library/Preferences/com.apogee.Apogee-Maestro-2.plist',
+               '~/Library/Saved Application State/com.apogee.Apogee-Maestro-2.savedState',
+               '~/Library/Saved Application State/com.apogee.SymphonyIO-Firmware-Updater.savedState',
+               '~/Library/Saved Application State/com.apogeedigital.ThunderBridge-Firmware-Updater.savedState',
+             ]
 
   caveats do
     reboot


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

A similar update to #724.