### PR TITLE
Synchronise apogee-* casks

### DIFF
--- a/Casks/apogee-duet.rb
+++ b/Casks/apogee-duet.rb
@@ -21,10 +21,8 @@ cask 'apogee-duet' do
                          'com.ApogeePopup.plist',
                          'com.DuetUSBDaemon.plist',
                        ],
-            quit:      [
-                         'com.apogee.Apogee-Maestro-.*',
-                         'com.apogee.Duet-USB-Firmware-Updater',
-                       ],
+            quit:      'com.apogee.Apogee-Maestro-.*',
+            signal:    ['TERM', 'com.apogee.Duet-USB-Firmware-Updater'],
             kext:      'com.apogeedigital.kext.ApogeeUSBDuetAudio',
             script:    [
                          executable: "#{staged_path}/Duet Uninstaller.app/Contents/Resources/DuetUSBUninstall.sh",
@@ -48,6 +46,7 @@ cask 'apogee-duet' do
                '~/Library/Caches/com.apogee.Apogee-Maestro-2',
                '~/Library/Caches/com.apogee.ApogeePopup',
                '~/Library/Preferences/com.apogee.Apogee-Maestro-2.plist',
+               '~/Library/Preferences/com.apogee.ApogeePopUp.plist',
                '~/Library/Saved Application State/com.apogee.Apogee-Maestro-2.savedState',
                '~/Library/Saved Application State/com.apogee.Duet-USB-Firmware-Updater.savedState',
              ]

--- a/Casks/apogee-one.rb
+++ b/Casks/apogee-one.rb
@@ -52,6 +52,7 @@ cask 'apogee-one' do
                '~/Library/Caches/com.apogee.Apogee-Maestro-2',
                '~/Library/Caches/com.apogee.ApogeePopup',
                '~/Library/Preferences/com.apogee.Apogee-Maestro-2.plist',
+               '~/Library/Preferences/com.apogee.ApogeePopUp.plist',
                '~/Library/Saved Application State/com.apogee.Apogee-Maestro-2.savedState',
              ]
 

--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -25,10 +25,10 @@ cask 'apogee-symphony-mkii' do
                        ],
             launchctl: 'com.SymphonyHelper.plist',
             quit:      [
-                         'com.apogeedigital.Symphony-IO-Mk-II-Thunderbolt-Firmware-Updater',
                          'com.apogeedigital.SymphonyControl',
                          'com.apogeedigital.SymphonyHelper',
                        ],
+            signal:    ['TERM', 'com.apogeedigital.Symphony-IO-Mk-II-Thunderbolt-Firmware-Updater'],
             kext:      'com.apogeedigital.kextSymphonyIO2T',
             script:    [
                          executable: "#{staged_path}/Symphony IO MkII Uninstaller.app/Contents/Resources/SymphonyIOMkIIUnInstall.sh",

--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -10,7 +10,7 @@ cask 'apogee-symphony-mkii' do
   url "https://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
   appcast 'http://www.apogeedigital.com/support/register/symphony-io-mk-ii'
   name 'Apogee Symphony I/O MkII'
-  homepage 'http://www.apogeedigital.com/support/symphony-io-mk-ii'
+  homepage 'http://www.apogeedigital.com/products/symphony-io'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/apogee-symphony.rb
+++ b/Casks/apogee-symphony.rb
@@ -31,11 +31,11 @@ cask 'apogee-symphony' do
                          'com.symphonyDaemon.plist',
                          'com.usbApogeeDaemon.plist',
                        ],
-            quit:      [
-                         'com.apogee.Apogee-Maestro-.*',
-                         'com.apogeedigital.ThunderBridge-Firmware-Updater',
+            quit:      'com.apogee.Apogee-Maestro-.*',
+            signal:    [
+                         ['TERM', 'com.apogee.SymphonyIO-Firmware-Updater'],
+                         ['TERM', 'com.apogeedigital.ThunderBridge-Firmware-Updater'],
                        ],
-            signal:    ['TERM', 'com.apogee.SymphonyIO-Firmware-Updater'],
             kext:      [
                          'com.apogee.driver.ApogeeUSBSymphonyIOAudio',
                          'com.apogeedigital.driver.Symphony64',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Synchronisation of common stanza's:
- Firmware update apps will sometimes not quit using the `quit` stanza. Therefore `signal` is used.
- Removal of user files related to a common `ApogeePopup` framework.
- Fix a `homepage` to use the product's page instead of the support page.