### PR TITLE
Rename apple-samsungprinterdrivers 2.6

### DIFF
--- a/Casks/apple-samsung-printer-drivers.rb
+++ b/Casks/apple-samsung-printer-drivers.rb
@@ -1,4 +1,4 @@
-cask 'apple-samsungprinterdrivers' do
+cask 'apple-samsung-printer-drivers' do
   version '2.6'
   sha256 'ecf283ff40df816e84d3a6148676114d2b4fe3f4074feb995c2c7e0be8be4964'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

A rename of this cask's token seems appropriate. The additional -'s improve readability, similarly to #753 and #754.