### PR TITLE
Update apple-brother-printer-drivers.rb to allow macOS > sierra

### DIFF
--- a/Casks/apple-brother-printer-drivers.rb
+++ b/Casks/apple-brother-printer-drivers.rb
@@ -7,7 +7,7 @@ cask 'apple-brother-printer-drivers' do
   name 'Brother Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1927'
 
-  depends_on macos: '<= :sierra'
+  depends_on macos: '<= :mojave'
 
   pkg 'BrotherPrinterDrivers.pkg'
 

--- a/Casks/apple-brother-printer-drivers.rb
+++ b/Casks/apple-brother-printer-drivers.rb
@@ -7,8 +7,6 @@ cask 'apple-brother-printer-drivers' do
   name 'Brother Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1927'
 
-  depends_on macos: '<= :mojave'
-
   pkg 'BrotherPrinterDrivers.pkg'
 
   uninstall quit:    [


### PR DESCRIPTION
I've tested this on Mojave `10.14.2` and it's working fine. Should we remove `depends_on macos:` out completely or change it to `mojave` just like this PR?

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
