### PR TITLE
apple-brother-printer-drivers.rb: depends_on <= sierra

### DIFF
--- a/Casks/apple-brother-printer-drivers.rb
+++ b/Casks/apple-brother-printer-drivers.rb
@@ -7,6 +7,8 @@ cask 'apple-brother-printer-drivers' do
   name 'Brother Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1927'
 
+  depends_on macos: '<= :sierra'
+
   pkg 'BrotherPrinterDrivers.pkg'
 
   uninstall quit:    [


### PR DESCRIPTION
Ping @bluenex and @ytbmulder.

Making this change since this is [Apple’s official recommendation](https://support.apple.com/kb/DL1927). [That it works on Mojave](https://github.com/Homebrew/homebrew-cask-drivers/pull/757#issue-248045499) might be a fluke, or a particularity of the system (e.g. I’ve seen drivers not work on a macOS version with a clean install, but work if the system was upgraded).

We should stick with the vendor’s recommendation. If a bug report is opened and they change the recommendation, we can change it in the cask as well.