### PR TITLE
Update blackvue-viewer to 1.31,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.30,74331'
-  sha256 'b9b088a0aa5af11dfc03ae98fe37dd37bb7f1a8e0d7cd264bd13e641483c7e7f'
+  version '1.31,74331'
+  sha256 '8abaf2363291940c483b5f9e805a4aead6d864d00acf2c19e5399fad2ce55b25'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.