### PR TITLE
Update elgato-stream-deck to 4.0.2.9798

### DIFF
--- a/Casks/elgato-stream-deck.rb
+++ b/Casks/elgato-stream-deck.rb
@@ -1,6 +1,6 @@
 cask 'elgato-stream-deck' do
-  version '4.0.1.9771'
-  sha256 'b4c06d8fb0ea4c87d7f0fb8fe75da30fb18aaa48dd413229f76d410d70ee2845'
+  version '4.0.2.9798'
+  sha256 '2f5780f31cfd450cfd1c8dd09126484a37387aff9bb95548e80ad862bc32836a'
 
   url "https://edge.elgato.com/egc/macos/sd/Stream_Deck_#{version}.pkg"
   appcast 'https://gaming.help.elgato.com/customer/en/portal/articles/2793637-elgato-stream-deck-software-release-notes'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.