### PR TITLE
Update apple-hewlett-packard-printer-drivers 5.1 uninstall and zap

### DIFF
--- a/Casks/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/apple-hewlett-packard-printer-drivers.rb
@@ -38,7 +38,27 @@ cask 'apple-hewlett-packard-printer-drivers' do
             pkgutil: [
                        'com.apple.pkg.HewlettPackardPrinterDrivers',
                        'com.apple.pkg.HewlettPackardPrinterDriversPreInstall',
+                     ],
+            delete:  [
+                       '/Library/Extensions/hp_io_enabler_compound.kext',
+                       '/Library/Printers/hp/hpio',
+                     ],
+            rmdir:   [
+                       '/Library/Printers/hp',
                      ]
+
+  zap trash: [
+               '~/Library/Logs/hp/HP Product Research.log',
+               '~/Library/Preferences/com.hp.HP-Scanner.plist',
+               '~/Library/Preferences/com.hp.printerutility.plist',
+               '~/Library/Preferences/com.hp.scanModule.plist',
+               '~/Library/Preferences/com.hp.scanModule3.plist',
+               '~/Library/Saved Application State/com.hp.printerutility.savedState',
+             ],
+      rmdir: [
+               '~/Library/Application Support/HP',
+               '~/Library/Logs/hp',
+             ]
 
   caveats do
     reboot

--- a/Casks/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/apple-hewlett-packard-printer-drivers.rb
@@ -34,6 +34,7 @@ cask 'apple-hewlett-packard-printer-drivers' do
                        'com.hp.scan.*',
                        'com.hp.scanModule.*',
                      ],
+            signal:  ['TERM', 'com.hp.printerutility'],
             kext:    'com.hp.kext.io.enabler.compound',
             pkgutil: [
                        'com.apple.pkg.HewlettPackardPrinterDrivers',
@@ -43,11 +44,10 @@ cask 'apple-hewlett-packard-printer-drivers' do
                        '/Library/Extensions/hp_io_enabler_compound.kext',
                        '/Library/Printers/hp/hpio',
                      ],
-            rmdir:   [
-                       '/Library/Printers/hp',
-                     ]
+            rmdir:   '/Library/Printers/hp'
 
   zap trash: [
+               '~/Library/Application Support/HP/Product Improvement Study',
                '~/Library/Logs/hp/HP Product Research.log',
                '~/Library/Preferences/com.hp.HP-Scanner.plist',
                '~/Library/Preferences/com.hp.printerutility.plist',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

