### PR TITLE
Update wootility to 3.0.1

### DIFF
--- a/Casks/wootility.rb
+++ b/Casks/wootility.rb
@@ -1,9 +1,9 @@
 cask 'wootility' do
-  version '2.4.0'
-  sha256 'a4d52d1a7162098fcdd25d28b6c1ae11c306782d9836c5c2a54b8cf8fa704c58'
+  version '3.0.1'
+  sha256 '46ce15a3c646034ed85f743c9945d37f9cb6f5c6b8dad122b059d805eb2ef7b2'
 
   # s3.eu-west-2.amazonaws.com/wooting-update was verified as official when first introduced to the cask
-  url "https://s3.eu-west-2.amazonaws.com/wooting-update/mac-latest/wootility-#{version}.dmg"
+  url "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-mac-latest/wootility-#{version}.dmg"
   name 'Wootility'
   homepage 'https://wooting.nl/wootility/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.