### PR TITLE
Update segger-ozone to 2.60n

### DIFF
--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -1,6 +1,6 @@
 cask 'segger-ozone' do
-  version '2.60m'
-  sha256 '2167484367a201714fa3b49020b2d94e71fe7aa02bb45c3acb3e626dcb2c68a0'
+  version '2.60n'
+  sha256 'ca3337744a12d49fbb59c3a590e28eb0cdcdb54ffbba7102f62a69c6a0ca7528'
 
   url "https://www.segger.com/downloads/jlink/Ozone_MacOSX_V#{version.no_dots}_Universal.pkg"
   name 'Ozone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.