### PR TITLE
Update wootility to 3.0.3

### DIFF
--- a/Casks/wootility.rb
+++ b/Casks/wootility.rb
@@ -1,6 +1,6 @@
 cask 'wootility' do
-  version '3.0.2'
-  sha256 '7e536ef51d0b85e42d44c4ef760fcb3d12f426896358405a1c710550e07e0773'
+  version '3.0.3'
+  sha256 '2f8329a77a445d143b705808b3fd9d7e0118de6d5159a0170d4611f81f118525'
 
   # s3.eu-west-2.amazonaws.com/wooting-update was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-mac-latest/wootility-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.