### PR TITLE
Update segger-jlink to 6.42c

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.42b'
-  sha256 '072267c12900bfb76ee6dec5e6895ddfda4af9909ff5fd4658bec30c0ca77c49'
+  version '6.42c'
+  sha256 '91baf1b4bf05553f8dbc5df00fea6b44eeb5aafb5b1b7deee848cf0430fbbcf7'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.