### PR TITLE
Update apple-samsung-printer-drivers 2.6 appcast, depends_on, uninstall and zap

### DIFF
--- a/Casks/apple-samsung-printer-drivers.rb
+++ b/Casks/apple-samsung-printer-drivers.rb
@@ -3,11 +3,17 @@ cask 'apple-samsung-printer-drivers' do
   sha256 'ecf283ff40df816e84d3a6148676114d2b4fe3f4074feb995c2c7e0be8be4964'
 
   url "https://support.apple.com/downloads/DL905/en_US/SamsungPrinterDrivers#{version}.dmg"
+  appcast 'https://support.apple.com/downloads/samsung'
   name 'Samsung Printer Drivers'
   homepage 'https://support.apple.com/kb/dl905'
+
+  depends_on macos: '<= :mavericks'
 
   pkg 'SamsungPrinterDrivers.pkg'
 
   uninstall quit:    'com.samsung.imagecapture.scanner.app',
-            pkgutil: 'com.apple.pkg.SamsungPrinterDrivers'
+            pkgutil: 'com.apple.pkg.SamsungPrinterDrivers',
+            rmdir:   '/Library/Printers/Samsung'
+
+  zap trash: '~/Library/Preferences/com.samsung.imagecapture.scanner.app.plist'
 end


### PR DESCRIPTION

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

According to Apple, this printer driver requires `mavericks` or below.
The driver did install on `sierra`, but this is a similar discussion as in #762.