### PR TITLE
Update segger-jlink to 6.42d

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.42c'
-  sha256 '91baf1b4bf05553f8dbc5df00fea6b44eeb5aafb5b1b7deee848cf0430fbbcf7'
+  version '6.42d'
+  sha256 '49dda56d60698a3b12ae86edaf9fe11144b69fff1adb2fdc96f2c6193bb22a4f'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.