### PR TITLE
Update silicon-labs-vcp-driver to 5.0.8

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,6 +1,6 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0.7'
-  sha256 '2a91d354a1e21746f324e3edd00ac6d320758a7b0b35ac8ab331eb993548c101'
+  version '5.0.8'
+  sha256 '5ce0f339eb094fa52dfb42b97d7441cdb6883026589ecdec2bd8f311dee34b99'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt'


### PR DESCRIPTION
According to [Mac_OSX_VCP_Driver_Release_Notes](https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt):

Release date: CP210x Macintosh OSX VCP Driver 5.0.8    - February 12, 2019
Changelog:
```
Version 5.0.8
	Added VID/PID for TAMRON Co., Ltd.
```

---
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256