### PR TITLE
Update nordic-nrf-connect to 2.6.2

### DIFF
--- a/Casks/nordic-nrf-connect.rb
+++ b/Casks/nordic-nrf-connect.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-connect' do
-  version '2.6.1'
-  sha256 '77b9224b906c034bff61ceaf7943c6d7091ba41961cfc26ae50c1d3b04a31cd4'
+  version '2.6.2'
+  sha256 '937c19f280b4c7744d364ca6ac36b15f2f67dd578c95a1d8477c324987d1d2a0'
 
   # github.com/NordicSemiconductor/pc-nrfconnect-core/ was verified as official when first introduced to the cask
   url "https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases/download/v#{version}/nrfconnect-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.