### PR TITLE
Update segger-jlink to 6.42e

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.42d'
-  sha256 '49dda56d60698a3b12ae86edaf9fe11144b69fff1adb2fdc96f2c6193bb22a4f'
+  version '6.42e'
+  sha256 '8d44866241b386e96019b48f6fb48b7c416e8dc0bf400ffbdce4fd992d93c312'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.