### PR TITLE
Update hdhomerun to 20190221

### DIFF
--- a/Casks/hdhomerun.rb
+++ b/Casks/hdhomerun.rb
@@ -1,6 +1,6 @@
 cask 'hdhomerun' do
-  version '20180817'
-  sha256 'fe36adef65b189e3ec3ff715e52515045a7241339bfad8ebd40982d518cc8c1a'
+  version '20190221'
+  sha256 'a7f4895b756e2876f8197c9b95a17a41d6d2e4997ff0c902e5fa0f72f9037569'
 
   url "https://download.silicondust.com/hdhomerun/hdhomerun_mac_#{version}.dmg"
   name 'HDHomeRun'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.