### PR TITLE
Update nvidia-cuda version to 10.1.105

### DIFF
--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -2,13 +2,12 @@ cask 'nvidia-cuda' do
   if MacOS.version <= :sierra
     version '9.0.176'
     sha256 '8fad950098337d2611d64617ca9f62c319d97c5e882b8368ed196e994bdaf225'
-    url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
   else
     version '10.1.105'
     sha256 '1d3355fa48b5763737f1c97a6436c774eda24ae91435e8ecc22428d23a01374a'
-    url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac"
   end
 
+  url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac.dmg"
   appcast 'https://developer.nvidia.com/cuda-toolkit-archive'
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'

--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -2,12 +2,13 @@ cask 'nvidia-cuda' do
   if MacOS.version <= :sierra
     version '9.0.176'
     sha256 '8fad950098337d2611d64617ca9f62c319d97c5e882b8368ed196e994bdaf225'
+    url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
   else
     version '10.1.105'
     sha256 '1d3355fa48b5763737f1c97a6436c774eda24ae91435e8ecc22428d23a01374a'
+    url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac.dmg"
   end
 
-  url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac.dmg"
   appcast 'https://developer.nvidia.com/cuda-toolkit-archive'
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'

--- a/Casks/nvidia-cuda.rb
+++ b/Casks/nvidia-cuda.rb
@@ -4,8 +4,8 @@ cask 'nvidia-cuda' do
     sha256 '8fad950098337d2611d64617ca9f62c319d97c5e882b8368ed196e994bdaf225'
     url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
   else
-    version '10.0.130'
-    sha256 '4f76261ed46d0d08a597117b8cacba58824b8bb1e1d852745658ac873aae5c8e'
+    version '10.1.105'
+    sha256 '1d3355fa48b5763737f1c97a6436c774eda24ae91435e8ecc22428d23a01374a'
     url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac"
   end
 


### PR DESCRIPTION
A new version of Cuda was just released, 10.1.105-1: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 
I haven't tested this. Because I'm on Linux. (But may need it because I depend on brew to install cuda in my Travis CI pipeline.)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
