### PR TITLE
Update wootility to 3.1.3

### DIFF
--- a/Casks/wootility.rb
+++ b/Casks/wootility.rb
@@ -1,6 +1,6 @@
 cask 'wootility' do
-  version '3.1.2'
-  sha256 '82141b7e7fbd35c634f91ae462d677834d337a4709d0b3528e0854a604d8dda5'
+  version '3.1.3'
+  sha256 '9f00c1ce9e7bad0c2dfe22046ebbd401488e057bdb66af45a676ee5030847633'
 
   # s3.eu-west-2.amazonaws.com/wooting-update was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-mac-latest/wootility-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.