### PR TITLE
Update segger-jlink to 6.44

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.42f'
-  sha256 '76783eb39bc00d4ebd82adabd0b2d9b08ec6f63ea553ac1ac8f97b00453e8b8a'
+  version '6.44'
+  sha256 '75ea6cfae921f34c392e33a8a0b5025124c44b2024b4068b1287d0c2dbaec5f6'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.