### PR TITLE
Update garmin-basecamp to 4.8.3

### DIFF
--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -10,7 +10,12 @@ cask 'garmin-basecamp' do
 
   pkg 'Install BaseCamp.pkg'
 
-  uninstall pkgutil: 'com.Garmin.*.BaseCamp*'
+  uninstall pkgutil:   [
+                         'com.Garmin.*.BaseCamp*',
+                         'com.Garmin.pkg.BasecampPostflight',
+                         'com.Garmin.pkg.MapInstall',
+                         'com.Garmin.pkg.MapManager',
+                       ]
 
   zap pkgutil: 'com.Garmin.*'
 end

--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -10,12 +10,12 @@ cask 'garmin-basecamp' do
 
   pkg 'Install BaseCamp.pkg'
 
-  uninstall pkgutil:   [
-                         'com.Garmin.*.BaseCamp*',
-                         'com.Garmin.pkg.BasecampPostflight',
-                         'com.Garmin.pkg.MapInstall',
-                         'com.Garmin.pkg.MapManager',
-                       ]
+  uninstall pkgutil: [
+                       'com.Garmin.*.BaseCamp*',
+                       'com.Garmin.pkg.BasecampPostflight',
+                       'com.Garmin.pkg.MapInstall',
+                       'com.Garmin.pkg.MapManager',
+                     ]
 
   zap pkgutil: 'com.Garmin.*'
 end

--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -1,6 +1,6 @@
 cask 'garmin-basecamp' do
-  version '4.7.0'
-  sha256 '43d2fcd3571fff70eeca2734c56e0aae0f982bc1a7019588bd55b883cc34b16c'
+  version '4.8.3'
+  sha256 'abbd7ac8bf9ac6dd976f04637e1cd916795bb838a34e60115f3b5fb3c72095fc'
 
   url "https://download.garmin.com/software/BaseCampforMac_#{version.no_dots}.dmg"
   name 'Garmin BaseCamp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.