### PR TITLE
Update fender-fuse 2.7.1 uninstall

### DIFF
--- a/Casks/fender-fuse.rb
+++ b/Casks/fender-fuse.rb
@@ -8,6 +8,18 @@ cask 'fender-fuse' do
   homepage 'https://fuse.fender.com/'
 
   pkg 'Fender FUSE Installer.app/Contents/Resources/Fender FUSE.pkg'
+  pkg 'Fender FUSE Installer.app/Contents/Resources/Fender Firmware Updater Installer.pkg'
 
-  uninstall pkgutil: 'com.Fender.pkg.FenderFUSE'
+  uninstall quit:    [
+                       'FenderFUSE',
+                       'Fender Firmware Updater',
+                     ],
+            pkgutil: [
+                       'com.Fender.pkg.FenderFUSE',
+                       'com.Fender.pkg.FenderAmpDrivers',
+                       'com.Fender.pkg.FenderFirmwareUpdater',
+                       'com.microsoft.SilverlightInstaller',
+                       'com.ximian.mono',
+                     ],
+            delete:  '/Applications/Fender FUSE.app'
 end

--- a/Casks/fender-fuse.rb
+++ b/Casks/fender-fuse.rb
@@ -23,5 +23,5 @@ cask 'fender-fuse' do
                      ],
             delete:  '/Applications/Fender FUSE.app'
 
-  zap trash: '~/Library/Application\ Support/Microsoft/Silverlight/OutOfBrowser/*.localhost'
+  zap trash: '~/Library/Application Support/Microsoft/Silverlight/OutOfBrowser/*.localhost'
 end

--- a/Casks/fender-fuse.rb
+++ b/Casks/fender-fuse.rb
@@ -22,4 +22,6 @@ cask 'fender-fuse' do
                        'com.ximian.mono',
                      ],
             delete:  '/Applications/Fender FUSE.app'
+
+  zap trash: '~/Library/Application\ Support/Microsoft/Silverlight/OutOfBrowser/*.localhost'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

While installation works flawlessly, when I try to open the `Fender FUSE.app` it returns the following in a pop-up window (on macOS 10.12.6):
```
The operation couldn't be completed. 
(OSStatus error -43.)
```

The `homepage` mentions `Mac OS X 10.7 or later`, which might indicate the age of this driver.

Could somebody test this driver on an older macOS version than I did and add the corresponding `depends_on macos:` stanza?