### PR TITLE
Update segger-jlink to 6.44a

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,11 +1,12 @@
 cask 'segger-jlink' do
-  version '6.44'
-  sha256 '75ea6cfae921f34c392e33a8a0b5025124c44b2024b4068b1287d0c2dbaec5f6'
+  version '6.44a'
+  sha256 '52329791bead88a7b4c59e2ef057a4953d9617b77ede6862ee2119ba8fbf0145'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,
       data:  {
                'accept_license_agreement' => 'accepted',
+               'non_emb_ctr'              => 'confirmed',
              }
   name 'Segger J-Link Command Line Tools'
   homepage 'https://www.segger.com/downloads/flasher'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.