### PR TITLE
Update logitech-unifying 1.3.375 to be compatible with mojave

### DIFF
--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -17,6 +17,7 @@ cask 'logitech-unifying' do
                       :el_capitan,
                       :sierra,
                       :high_sierra,
+                      :mojave,
                     ]
 
   pkg 'Unifying Installer.app/Contents/Resources/Logitech Unifying Signed.mpkg'


### PR DESCRIPTION
Tested on 10.14.3 working.  This adds the mojave slug to the allowed versions.  This may need to be something like a documented exception as the officially supported versions do not list this.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).