### PR TITLE
Fix jabra-direct version number

### DIFF
--- a/Casks/jabra-direct.rb
+++ b/Casks/jabra-direct.rb
@@ -1,5 +1,5 @@
 cask 'jabra-direct' do
-  version '1.0.12'
+  version '4.0.4381'
   sha256 'bd923b5ce38887e1fc56fbb5418f9a548932f0f9ad18e88d832b17e7e164dc90'
 
   # jabraxpressonlineprdstor.blob.core.windows.net/jdo was verified as official when first introduced to the cask


### PR DESCRIPTION
not sure where this 1.0.12 came from, but its neither in the website, nor in the app itself. and not in the URL either.