### PR TITLE
 Add nvidia-web-driver 387.10.10.10.40.122 uninstall script

### DIFF
--- a/Casks/jabra-direct.rb
+++ b/Casks/jabra-direct.rb
@@ -1,6 +1,6 @@
 cask 'jabra-direct' do
-  version '4.0.3913'
-  sha256 '3d5e9e5156248baa3e4ff5403e6c4abe845dd79210583045146a56b8d0787bc1'
+  version '1.0.12'
+  sha256 'bd923b5ce38887e1fc56fbb5418f9a548932f0f9ad18e88d832b17e7e164dc90'
 
   # jabraxpressonlineprdstor.blob.core.windows.net/jdo was verified as official when first introduced to the cask
   url 'https://jabraxpressonlineprdstor.blob.core.windows.net/jdo/JabraDirectSetup.dmg'

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -14,7 +14,7 @@ cask 'nvidia-web-driver' do
   end
 
   module Utils
-    def self.basename()
+    def self.basename
       '/Library/PreferencePanes/NVIDIA Driver Manager.prefPane/Contents/MacOS/NVIDIA Web Driver Uninstaller.app/Contents/Resources'
     end
   end
@@ -35,7 +35,7 @@ cask 'nvidia-web-driver' do
 
   uninstall_preflight do
     system_command '/usr/sbin/pkgutil',
-                   args: ['--expand', "#{Utils.basename()}/NVUninstall.pkg", "#{Utils.basename()}/NVUninstall"],
+                   args: ['--expand', "#{Utils.basename}/NVUninstall.pkg", "#{Utils.basename}/NVUninstall"],
                    sudo: true
   end
 
@@ -54,7 +54,7 @@ cask 'nvidia-web-driver' do
                          'com.nvidia.web.NVDA*Web',
                        ],
             script:    [ # Only the third argument is used and should be the system's root path
-                         executable: "#{Utils.basename()}/NVUninstall/Scripts/postinstall",
+                         executable: "#{Utils.basename}/NVUninstall/Scripts/postinstall",
                          args:       ['/', '/', '/'],
                          sudo:       true,
                        ],

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -41,7 +41,13 @@ cask 'nvidia-web-driver' do
                          'com.nvidia.web.GeForce*Web',
                          'com.nvidia.web.NVDA*Web',
                        ],
-            pkgutil:   'com.nvidia.web-driver'
+            pkgutil:   'com.nvidia.web-driver',
+            delete:    '/Library/PreferencePanes/NVIDIA Driver Manager.prefPane'
+
+  zap trash: [
+               '~/Library/Preferences/ByHost/com.nvidia.nvagent.*.plist',
+               '~/Library/Preferences/ByHost/com.nvidia.nvprefpane.*.plist',
+             ]
 
   caveats do
     reboot

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -13,6 +13,12 @@ cask 'nvidia-web-driver' do
     sha256 '2f7701fa8b2edfcb51ed529ea76f6a5b42e3522f2ecdf278b127c2f9b4c296ed'
   end
 
+  module Utils
+    def self.basename()
+      '/Library/PreferencePanes/NVIDIA Driver Manager.prefPane/Contents/MacOS/NVIDIA Web Driver Uninstaller.app/Contents/Resources'
+    end
+  end
+
   url "https://images.nvidia.com/mac/pkg/#{version.major}/WebDriver-#{version}.pkg"
   appcast 'https://gfe.nvidia.com/mac-update'
   name 'NVIDIA Web Driver'
@@ -27,6 +33,12 @@ cask 'nvidia-web-driver' do
 
   pkg "WebDriver-#{version}.pkg"
 
+  uninstall_preflight do
+    system_command '/usr/sbin/pkgutil',
+                   args: ['--expand', "#{Utils.basename()}/NVUninstall.pkg", "#{Utils.basename()}/NVUninstall"],
+                   sudo: true
+  end
+
   uninstall launchctl: [
                          'com.nvidia.nvagent',
                          'com.nvidia.nvroothelper',
@@ -40,6 +52,11 @@ cask 'nvidia-web-driver' do
                          'com.nvidia.NVDAStartupWeb',
                          'com.nvidia.web.GeForce*Web',
                          'com.nvidia.web.NVDA*Web',
+                       ],
+            script:    [ # Only the third argument is used and should be the system's root path
+                         executable: "#{Utils.basename()}/NVUninstall/Scripts/postinstall",
+                         args:       ['/', '/', '/'],
+                         sudo:       true,
                        ],
             pkgutil:   'com.nvidia.web-driver',
             delete:    '/Library/PreferencePanes/NVIDIA Driver Manager.prefPane'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The `nvidia-web-driver` contains an uninstall script inside a `pkg`. This `pkg` is first expanded inside the `prefPane` directory, such that it will be deleted during uninstall. The script itself fails if no third argument is given, even though the first two arguments are not used in the script itself. This argument has to be the system's root path `/`. The other two arguments are equal to the third argument.

One of the interesting things that the uninstall script does, is to clear `NVRAM` settings set by the driver.