### PR TITLE
Update ubiquiti-unifi-controller 5.10.19 quit, zap and caveats

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -29,6 +29,7 @@ cask 'ubiquiti-unifi-controller' do
 
   zap trash: [
                '~/Library/Application Support/UniFi',
+               '~/Library/Saved Application State/com.ubnt.UniFi-Discover.savedState',
                '~/Library/Saved Application State/com.ubnt.UniFi.savedState',
              ]
 

--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -4,7 +4,7 @@ cask 'ubiquiti-unifi-controller' do
 
   # dl.ubnt.com was verified as official when first introduced to the cask
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
-  appcast 'https://www.ubnt.com/download/unifi'
+  appcast 'https://www.ui.com/download/unifi'
   name 'Ubiquiti UniFi Network Controller'
   homepage 'https://unifi-sdn.ui.com/'
 

--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -2,10 +2,11 @@ cask 'ubiquiti-unifi-controller' do
   version '5.10.19'
   sha256 '2dea4802ccc5203d29956f5c970fc676afae484ba94255e61f11807422c66547'
 
+  # dl.ubnt.com was verified as official when first introduced to the cask
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   appcast 'https://www.ubnt.com/download/unifi'
   name 'Ubiquiti UniFi Network Controller'
-  homepage 'https://unifi-sdn.ui.com'
+  homepage 'https://unifi-sdn.ui.com/'
 
   conflicts_with cask: 'ubiquiti-unifi-controller-lts'
 
@@ -28,7 +29,7 @@ cask 'ubiquiti-unifi-controller' do
 
   zap trash: [
                '~/Library/Application Support/UniFi',
-               '~/Library/Saved Application State/com.ubnt.UniFi.savedState'
+               '~/Library/Saved Application State/com.ubnt.UniFi.savedState',
              ]
 
   caveats do

--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -3,9 +3,9 @@ cask 'ubiquiti-unifi-controller' do
   sha256 '2dea4802ccc5203d29956f5c970fc676afae484ba94255e61f11807422c66547'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
-  appcast 'https://www.ubnt.com/download/unifi/'
-  name 'UniFi Controller'
-  homepage 'https://www.ubnt.com/download/unifi/'
+  appcast 'https://www.ubnt.com/download/unifi'
+  name 'Ubiquiti UniFi Network Controller'
+  homepage 'https://unifi-sdn.ui.com'
 
   conflicts_with cask: 'ubiquiti-unifi-controller-lts'
 
@@ -15,11 +15,23 @@ cask 'ubiquiti-unifi-controller' do
     set_ownership '~/Library/Application Support/UniFi'
   end
 
-  uninstall pkgutil: 'com.ubnt.UniFi',
+  uninstall quit:    [
+                       'com.oracle.java.*.jre',
+                       'com.ubnt.UniFi-Discover',
+                     ],
+            signal:  ['TERM', 'com.ubnt.UniFi'],
+            pkgutil: 'com.ubnt.UniFi',
             delete:  [
-                       '/Applications/UniFi.app',
                        '/Applications/UniFi-Discover.app',
+                       '/Applications/UniFi.app',
                      ]
 
-  zap trash: '~/Library/Application Support/UniFi'
+  zap trash: [
+               '~/Library/Application Support/UniFi',
+               '~/Library/Saved Application State/com.ubnt.UniFi.savedState'
+             ]
+
+  caveats do
+    license 'https://www.ui.com/eula/'
+  end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The `appcast` and `homepage` were the same link.