### PR TITLE
Update ubiquiti-unifi-controller-lts 5.6.40 quit, zap and caveats

### DIFF
--- a/Casks/ubiquiti-unifi-controller-lts.rb
+++ b/Casks/ubiquiti-unifi-controller-lts.rb
@@ -2,9 +2,11 @@ cask 'ubiquiti-unifi-controller-lts' do
   version '5.6.40'
   sha256 '930000ca5382faf5f75dcbdd7c85ca39a2769ca7c37d7a2c3c33ea460c26bf93'
 
+  # dl.ubnt.com was verified as official when first introduced to the cask
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
-  name 'UniFi Controller - LTS version'
-  homepage 'https://www.ubnt.com/download/unifi/'
+  appcast 'https://www.ui.com/download/unifi'
+  name 'Ubiquiti UniFi SDN Controller LTS'
+  homepage 'https://unifi-sdn.ui.com/'
 
   conflicts_with cask: 'ubiquiti-unifi-controller'
 
@@ -14,11 +16,24 @@ cask 'ubiquiti-unifi-controller-lts' do
     set_ownership '~/Library/Application Support/UniFi'
   end
 
-  uninstall pkgutil: 'com.ubnt.UniFi',
+  uninstall quit:    [
+                       'com.oracle.java.*.jre',
+                       'com.ubnt.UniFi-Discover',
+                     ],
+            signal:  ['TERM', 'com.ubnt.UniFi'],
+            pkgutil: 'com.ubnt.UniFi',
             delete:  [
-                       '/Applications/UniFi.app',
                        '/Applications/UniFi-Discover.app',
+                       '/Applications/UniFi.app',
                      ]
 
-  zap trash: '~/Library/Application Support/UniFi'
+  zap trash: [
+               '~/Library/Application Support/UniFi',
+               '~/Library/Saved Application State/com.ubnt.UniFi-Discover.savedState',
+               '~/Library/Saved Application State/com.ubnt.UniFi.savedState',
+             ]
+
+  caveats do
+    license 'https://www.ui.com/eula/'
+  end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

