### PR TITLE
Add openbci-gui 4.1.0 uninstall and trash

### DIFF
--- a/Casks/openbci-gui.rb
+++ b/Casks/openbci-gui.rb
@@ -1,6 +1,6 @@
 cask 'openbci-gui' do
   version '4.1.0'
-  sha256 '9142823e81fefb67f514468c5cad35e47fc38d815dc94d2b81e889a814f89763'
+  sha256 'ff9dd9fda3f6f05289ccba5c028dfa819c47c46317fa0288abf1543207f0334c'
 
   # github.com/OpenBCI/OpenBCI_GUI was verified as official when first introduced to the cask
   url "https://github.com/OpenBCI/OpenBCI_GUI/releases/download/v#{version}/application.macosx.zip"
@@ -9,4 +9,22 @@ cask 'openbci-gui' do
   homepage 'https://openbci.com/'
 
   app 'application.macosx/OpenBCI_GUI.app'
+
+  uninstall quit:   [
+                      'OpenBCI_GUI',
+                      'com.github.Squirrel',
+                      'com.github.electron.framework',
+                      'com.openbci.hub.*',
+                      'org.mantle.Mantle',
+                      'org.reactivecocoa.ReactiveCocoa',
+                    ]
+
+  zap trash: [
+               '~/Library/Application Support/OpenBCIHub',
+               '~/Library/Logs/OpenBCIHub',
+               '~/Library/Preferences/com.openbci.hub.plist',
+               '~/Library/Saved Application State/OpenBCI_GUI.savedState',
+               '~/Library/Saved Application State/com.openbci.hub.savedState',
+             ]
+
 end

--- a/Casks/openbci-gui.rb
+++ b/Casks/openbci-gui.rb
@@ -10,14 +10,14 @@ cask 'openbci-gui' do
 
   app 'application.macosx/OpenBCI_GUI.app'
 
-  uninstall quit:   [
-                      'OpenBCI_GUI',
-                      'com.github.Squirrel',
-                      'com.github.electron.framework',
-                      'com.openbci.hub.*',
-                      'org.mantle.Mantle',
-                      'org.reactivecocoa.ReactiveCocoa',
-                    ]
+  uninstall quit: [
+                    'OpenBCI_GUI',
+                    'com.github.Squirrel',
+                    'com.github.electron.framework',
+                    'com.openbci.hub.*',
+                    'org.mantle.Mantle',
+                    'org.reactivecocoa.ReactiveCocoa',
+                  ]
 
   zap trash: [
                '~/Library/Application Support/OpenBCIHub',
@@ -26,5 +26,4 @@ cask 'openbci-gui' do
                '~/Library/Saved Application State/OpenBCI_GUI.savedState',
                '~/Library/Saved Application State/com.openbci.hub.savedState',
              ]
-
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The `sha256` was incorrect during installation and was therefore updated.
