### PR TITLE
Update steelseries-engine 3.13.10 uninstall and depends_on

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -28,13 +28,13 @@ cask 'steelseries-engine' do
                          sudo:       true,
                        ],
             pkgutil:   'com.steelseries.*',
-            delete:    '/Library/Application Support/SteelSeries Engine 3'
+            delete:    "/Library/Application Support/SteelSeries Engine #{version.major}"
 
   zap trash: [
-               '~/Library/Application Support/steelseries-engine-3-client',
-               '~/Library/Caches/com.steelseries.SteelSeries-Engine-3',
-               '~/Library/Logs/SteelSeries Engine 3 Client',
-               '~/Library/Preferences/com.steelseries.SteelSeries-Engine-3.plist',
+               "~/Library/Application Support/steelseries-engine-#{version.major}-client",
+               "~/Library/Caches/com.steelseries.SteelSeries-Engine-#{version.major}",
+               "~/Library/Logs/SteelSeries Engine #{version.major} Client",
+               "~/Library/Preferences/com.steelseries.SteelSeries-Engine-#{version.major}.plist",
                '~/Library/Preferences/com.steelseries.ssenext.client.helper.plist',
                '~/Library/Preferences/com.steelseries.ssenext.client.plist',
                '~/Library/Saved Application State/com.steelseries.ssenext.client.savedState',

--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -7,19 +7,36 @@ cask 'steelseries-engine' do
   name "SteelSeries Engine #{version.major}"
   homepage 'https://steelseries.com/engine'
 
+  auto_updates
+  depends_on macos: '>= :yosemite'
+
   pkg "SteelSeriesEngine#{version}.pkg"
 
-  uninstall pkgutil:   'com.steelseries.*',
+  uninstall launchctl: 'com.steelseries.SSENext',
+            quit:      [
+                         'com.github.Electron.framework',
+                         'com.github.Squirrel',
+                         "com.steelseries.SteelSeries-Engine-#{version.major}",
+                         'com.steelseries.ssenext.client.*',
+                         'com.steelseries.ssenext.uninstaller',
+                         'org.mantle.Mantle',
+                         'org.reactivecocoa.ReactiveCocoa',
+                       ],
             kext:      'com.steelseries.ssenext.driver',
-            launchctl: 'com.steelseries.SSENext',
-            quit:      "com.steelseries.SteelSeries-Engine-#{version.major}"
+            script:    [
+                         executable: "/Applications/SteelSeries Engine #{version.major}/SteelSeries Engine #{version.major} Uninstaller.app/Contents/Resources/Uninstall.sh",
+                         sudo:       true,
+                       ],
+            pkgutil:   'com.steelseries.*',
+            delete:    '/Library/Application Support/SteelSeries Engine 3'
 
   zap trash: [
-               '/Library/Application Support/SteelSeries Engine 3',
                '~/Library/Application Support/steelseries-engine-3-client',
                '~/Library/Caches/com.steelseries.SteelSeries-Engine-3',
+               '~/Library/Logs/SteelSeries Engine 3 Client',
                '~/Library/Preferences/com.steelseries.SteelSeries-Engine-3.plist',
                '~/Library/Preferences/com.steelseries.ssenext.client.helper.plist',
                '~/Library/Preferences/com.steelseries.ssenext.client.plist',
+               '~/Library/Saved Application State/com.steelseries.ssenext.client.savedState',
              ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

