### PR TITLE
Update segger-jlink to 6.44c

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,15 +1,15 @@
 cask 'segger-jlink' do
-  version '6.44b'
-  sha256 '37472ffab2728858d52cceef9ea684fc1131328ccd64f37b26a97b5af3be392a'
+  version '6.44c'
+  sha256 'de9c855a4d69a93cefad67515fd60204b75780ba480502dfb8f0e69b8705394e'
 
-  url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
+  url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,
       data:  {
                'accept_license_agreement' => 'accepted',
                'non_emb_ctr'              => 'confirmed',
              }
   name 'Segger J-Link Command Line Tools'
-  homepage 'https://www.segger.com/downloads/flasher'
+  homepage 'https://www.segger.com/downloads/jlink'
 
   pkg "JLink_MacOSX_V#{version.no_dots}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.