### PR TITLE
Remove steelseries-engine 3.13.10 common frameworks

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -14,13 +14,9 @@ cask 'steelseries-engine' do
 
   uninstall launchctl: 'com.steelseries.SSENext',
             quit:      [
-                         'com.github.Electron.framework',
-                         'com.github.Squirrel',
                          "com.steelseries.SteelSeries-Engine-#{version.major}",
                          'com.steelseries.ssenext.client.*',
                          'com.steelseries.ssenext.uninstaller',
-                         'org.mantle.Mantle',
-                         'org.reactivecocoa.ReactiveCocoa',
                        ],
             kext:      'com.steelseries.ssenext.driver',
             script:    [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

