### PR TITLE
Update blackvue-viewer to 1.32,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -3,9 +3,9 @@ cask 'blackvue-viewer' do
   sha256 '4f74a31e058fd55c635424606c698dfa2c91e52575ced58085e17be5e61b094f'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
-  appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=74331'
   name 'BlackVue Viewer'
-  homepage 'https://www.blackvue.com/'
+  homepage 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.31,74331'
-  sha256 '8abaf2363291940c483b5f9e805a4aead6d864d00acf2c19e5399fad2ce55b25'
+  version '1.32,74331'
+  sha256 '4f74a31e058fd55c635424606c698dfa2c91e52575ced58085e17be5e61b094f'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'

--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -3,7 +3,7 @@ cask 'blackvue-viewer' do
   sha256 '4f74a31e058fd55c635424606c698dfa2c91e52575ced58085e17be5e61b094f'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
-  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=74331'
+  appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'
   name 'BlackVue Viewer'
   homepage 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.