### PR TITLE
Update segger-jlink from 6.44c to 6.44d

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.44c'
-  sha256 'de9c855a4d69a93cefad67515fd60204b75780ba480502dfb8f0e69b8705394e'
+  version '6.44d'
+  sha256 '6f679e3a88007083e73c338701056e48d7cb205726078973f49b3d02330c31aa'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.