### PR TITLE
Update swannview-link to 2.2.7.25

### DIFF
--- a/Casks/swannview-link.rb
+++ b/Casks/swannview-link.rb
@@ -4,6 +4,7 @@ cask 'swannview-link' do
 
   # dropbox.com/s/os2ye4i2nv49csq was verified as official when first introduced to the cask
   url "https://www.dropbox.com/s/os2ye4i2nv49csq/SwannView%20Link%20Mac%20#{version}dmg?dl=1"
+  appcast 'https://swann.desk.com/customer/en/portal/articles/2171357-swannview-link-for-mac'
   name 'SwannView Link'
   homepage 'https://swann.desk.com/customer/en/portal/articles/2171357-swannview-link-for-mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.