### PR TITLE
Update wootility to 3.1.3

### DIFF
--- a/Casks/wootility.rb
+++ b/Casks/wootility.rb
@@ -4,6 +4,7 @@ cask 'wootility' do
 
   # s3.eu-west-2.amazonaws.com/wooting-update was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-mac-latest/wootility-#{version}.dmg"
+  appcast 'https://wooting.io/wootility'
   name 'Wootility'
   homepage 'https://wooting.nl/wootility/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.