### PR TITLE
Update lacie-network-assistant to 1.5.17

### DIFF
--- a/Casks/lacie-network-assistant.rb
+++ b/Casks/lacie-network-assistant.rb
@@ -3,8 +3,9 @@ cask 'lacie-network-assistant' do
   sha256 'fce25a342d9b54fb438ece6a17e3ed1391f1b41a5e9fd4e9459d0ca0fe828df9'
 
   url "https://www.lacie.com/files/lacie-content/download/drivers/LaCie%20Network%20Assistant-#{version}.dmg"
+  appcast 'https://www.lacie.com/gb/en/support/network-storage/cloudbox/'
   name 'LaCie Network Assistant'
-  homepage 'https://www.lacie.com/ch/fr/support/network-storage/cloudbox/'
+  homepage 'https://www.lacie.com/gb/en/support/network-storage/cloudbox/'
 
   app 'LaCie Network Assistant.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.