### PR TITLE
Update synology-photo-station-uploader to 1.4.4-091

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -3,6 +3,7 @@ cask 'synology-photo-station-uploader' do
   sha256 'f25e009170387720291570d3acfef048d9ee05477c5a0b207df965ddf924d4cb'
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
+  appcast 'https://archive.synology.com/download/Tools/PhotoStationUploader/'
   name 'Synology Photo Station Uploader'
   homepage 'https://www.synology.com/'
 

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -10,7 +10,9 @@ cask 'synology-photo-station-uploader' do
   pkg "PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.pkg"
 
   uninstall pkgutil:   'com.synology.photostationuploader.installer',
+            quit:      'com.synology.PhotoStationUploader',
             launchctl: [
+                         'com.synology.PhotoUploaderFinderSync',
                          'com.synology.PhotoUploaderShellApp',
                          'com.synology.SynoSIMBL_RefreshFinder',
                        ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.