### PR TITLE
Update garmin-basecamp from 4.8.3 to 4.8.4

### DIFF
--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -1,8 +1,9 @@
 cask 'garmin-basecamp' do
-  version '4.8.3'
-  sha256 'abbd7ac8bf9ac6dd976f04637e1cd916795bb838a34e60115f3b5fb3c72095fc'
+  version '4.8.4'
+  sha256 '8d3595428caa289a15177eb483937bcb5dfd3399746ffc09c59c698c6f5d68e5'
 
   url "https://download.garmin.com/software/BaseCampforMac_#{version.no_dots}.dmg"
+  appcast 'https://www8.garmin.com/support/download_details.jsp?id=4449'
   name 'Garmin BaseCamp'
   homepage 'https://www.garmin.com/en-US/shop/downloads/basecamp'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.