### PR TITLE
Update evolv-escribe-suite.rb to 2_SP20

### DIFF
--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -1,6 +1,6 @@
 cask 'evolv-escribe-suite' do
-  version '2_SP19'
-  sha256 'e2544857312c5ddbffce0c66c88e86aa424f5c779123064e0283ac634c101ed4'
+  version '2_SP20'
+  sha256 '5805ebdad6095cf1c79add7091311ac3ec8465c43ceab6d1cc064693a95d1bcc'
 
   url "https://downloads.evolvapor.com/SetupEScribe#{version}_INT.pkg"
   name 'EScribe Suite'


### PR DESCRIPTION
This is the latest version which is not official available on the Evolve Website 
but this version fix the startup issue on Mac-Mojave.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256