### PR TITLE
Remove apple-hewlett-packard-printer-drivers 5.1 depends_on macos

### DIFF
--- a/Casks/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/apple-hewlett-packard-printer-drivers.rb
@@ -7,8 +7,6 @@ cask 'apple-hewlett-packard-printer-drivers' do
   name 'HP Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1888'
 
-  depends_on macos: '<= :high_sierra'
-
   pkg 'HewlettPackardPrinterDrivers.pkg'
 
   uninstall quit:    [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

As discussed in https://github.com/Homebrew/homebrew-cask-drivers/issues/856.
Also addresses an earlier pull request: https://github.com/Homebrew/homebrew-cask-drivers/pull/892.