### PR TITLE
Update synology-cloud-station-backup from 4.3.0-4435 to 4.3.1-4437

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -11,7 +11,10 @@ cask 'synology-cloud-station-backup' do
 
   pkg 'Install Cloud Station Backup.pkg'
 
-  uninstall quit:      'com.synology.CloudStationBackupUI',
+  uninstall quit:      [
+                         'com.synology.CloudStationBackup',
+                         'com.synology.CloudStationBackupUI',
+                       ],
             pkgutil:   [
                          'com.synology.CloudStationBackup',
                          'com.synology.CloudStationBackupUI',

--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -11,7 +11,10 @@ cask 'synology-cloud-station-backup' do
 
   pkg 'Install Cloud Station Backup.pkg'
 
-  uninstall pkgutil:   'com.synology.CloudStationBackup',
+  uninstall pkgutil:   [
+                         'com.synology.CloudStationBackup',
+                         'com.synology.CloudStationBackupUI',
+                       ],
             launchctl: 'com.synology.Synology Cloud Station Backup'
 
   zap trash: '~/Library/Preferences/com.synology.CloudStationBackupUI.plist'

--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -1,6 +1,6 @@
 cask 'synology-cloud-station-backup' do
-  version '4.3.0-4435'
-  sha256 'f0c83e70578fd209ad46aef2c14767b78b14fb0d62c23daf5f655802fa9c578a'
+  version '4.3.1-4437'
+  sha256 'e1faf8be16ab3e39cf0efe086f5e3b746285b4aec970c1d8c25502cf820ca6ca'
 
   url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
   appcast 'https://archive.synology.com/download/Tools/CloudStationBackup/'

--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -11,7 +11,8 @@ cask 'synology-cloud-station-backup' do
 
   pkg 'Install Cloud Station Backup.pkg'
 
-  uninstall pkgutil:   [
+  uninstall quit:      'com.synology.CloudStationBackupUI',
+            pkgutil:   [
                          'com.synology.CloudStationBackup',
                          'com.synology.CloudStationBackupUI',
                        ],


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.