### PR TITLE
Update wootility from 3.1.3 to 3.2.5

### DIFF
--- a/Casks/wootility.rb
+++ b/Casks/wootility.rb
@@ -1,6 +1,6 @@
 cask 'wootility' do
-  version '3.1.3'
-  sha256 '86c7e0945fb7110728ee85d188d61963f0e8c9e3068a490d97ff24a091e41669'
+  version '3.2.5'
+  sha256 'a283251399882018237841462cdd0af50b69cacb3c1712bde40a2da5af3c1673'
 
   # s3.eu-west-2.amazonaws.com/wooting-update was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-mac-latest/wootility-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.