### PR TITLE
Update wootility from 3.2.5 to 3.2.6

### DIFF
--- a/Casks/wootility.rb
+++ b/Casks/wootility.rb
@@ -1,6 +1,6 @@
 cask 'wootility' do
-  version '3.2.5'
-  sha256 'a283251399882018237841462cdd0af50b69cacb3c1712bde40a2da5af3c1673'
+  version '3.2.6'
+  sha256 'b5929c7de16f771d5a073c7fc215767644bc271b323291937f351963601d8f3a'
 
   # s3.eu-west-2.amazonaws.com/wooting-update was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-mac-latest/wootility-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.