### PR TITLE
Add silicon-labs-vcp-driver 4.11.3

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,5 +1,12 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0.10'
+  if MacOS.version <= :yosemite
+    version '4.11.3'
+    pkg 'Legacy MacVCP Driver/Silicon Labs VCP Driver.pkg'
+  else
+    version '5.0.10'
+    pkg 'Silicon Labs VCP Driver.pkg'
+  end
+
   sha256 '375823a96b2cdac4c8bb195cc85d149e7e5a6f8ef572c097ea691796da6edaf4'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
@@ -8,10 +15,7 @@ cask 'silicon-labs-vcp-driver' do
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'
 
-  depends_on macos: '>= :el_capitan'
   container nested: 'Mac_OSX_VCP_Driver/SiLabsUSBDriverDisk.dmg'
-
-  pkg 'Silicon Labs VCP Driver.pkg'
 
   uninstall kext:    'com.silabs.driver.CP210xVCPDriver',
             script:  [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The download contains installers for macOS before and after `yosemite`.