### PR TITLE
Update segger-jlink from 6.44g to 6.44h

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.44g'
-  sha256 'e12ddb8ee34011a3c887be26cb3fcecce6823fd43059b49a27e01a468a0e7834'
+  version '6.44h'
+  sha256 '9fd8f216020d91ce41dfa093295681f81662bbf6b28711e60a70d89ceaa81d5c'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.