### PR TITLE
Update evolv-escribe-suite from 2_SP20 to 2_SP19

### DIFF
--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -1,6 +1,6 @@
 cask 'evolv-escribe-suite' do
-  version '2_SP20'
-  sha256 '5805ebdad6095cf1c79add7091311ac3ec8465c43ceab6d1cc064693a95d1bcc'
+  version '2_SP19'
+  sha256 'e2544857312c5ddbffce0c66c88e86aa424f5c779123064e0283ac634c101ed4'
 
   url "https://downloads.evolvapor.com/SetupEScribe#{version}_INT.pkg"
   name 'EScribe Suite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.