### PR TITLE
Update segger-ozone from 2.62a to 2.62b

### DIFF
--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -1,6 +1,6 @@
 cask 'segger-ozone' do
-  version '2.62a'
-  sha256 '7837ced6192dfd9f90d3d147f0814b5a52bba9f15d5690ef7a5b086db09ca214'
+  version '2.62b'
+  sha256 'bc5eba90218b1853b17db200c96819a331ee2432afd2ae4660a6394ba65e6e56'
 
   url "https://www.segger.com/downloads/jlink/Ozone_MacOSX_V#{version.no_dots}_Universal.pkg"
   name 'Ozone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.