### PR TITLE
Update wd-security 2.1.1.61 uninstall and zap

### DIFF
--- a/Casks/wd-security.rb
+++ b/Casks/wd-security.rb
@@ -3,13 +3,28 @@ cask 'wd-security' do
   sha256 'b6744537b81a4bfb27c23413e457ddf74864220734a59a0df5ee0e48d90de8f5'
 
   url "http://downloads.wdc.com/wdapp/WD_Security_Standalone_Installer_Mac_#{version.dots_to_underscores}.zip"
+  appcast 'https://support.wdc.com/downloads.aspx?lang=en'
   name 'WD Security'
-  homepage 'https://www.wdc.com/'
+  homepage 'https://support.wdc.com/downloads.aspx?lang=en'
 
   installer manual: 'WD Security Installer.app'
 
-  uninstall script: {
-                      executable: '/Applications/WD Security Uninstaller.app/Contents/MacOS/WD Security Installer',
-                      sudo:       true,
-                    }
+  uninstall launchctl: 'com.wdc.WDPrivilegedHelper',
+            quit:      [
+                         'com.wdc.branded.security',
+                         'com.westerndigital.WDSecurityHelper',
+                         'com.westerndigital.WDSecurityInstaller',
+                       ],
+            script:    [
+                         executable: '/Applications/WD Security Uninstaller.app/Contents/MacOS/WD Security Installer',
+                         sudo:       true,
+                       ]
+
+  zap trash: [
+               '/Library/LaunchDaemons/com.wdc.WDPrivilegedHelper.plist',
+               '~/Library/Caches/com.apple.helpd/Generated/com.wdc.branded.security.help',
+               '~/Library/Caches/com.wdc.branded.security',
+               '~/Library/Caches/com.westerndigital.WDSecurityInstaller',
+               '~/Library/Preferences/com.wdc.branded.security.plist',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

