### PR TITLE
chore: upgrade displaylink to 5.1.1 for Mojave

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -9,8 +9,8 @@ cask 'displaylink' do
     version '4.3.1,1251'
     sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'
   else
-    version '5.1,1302'
-    sha256 '3befe52b5c8c3cc0a081f831744d82106051fb665c1b9f11b2787296cc067879'
+    version '5.1.1,1334'
+    sha256 '1ac9093f8113af8c35d6f3ff5b1ae3f119a5aff0d5309d75c7a1742f159184b5'
   end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",


### PR DESCRIPTION
5.1.1 was released on 18th April 2019 with the following bug fix:

> Due to new driver notarization requirement in 10.14.5 Beta 2, DisplayLink driver was not available in security & privacy settings to be allowed. (20831)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
