### PR TITLE
Update segger-jlink.rb 6.44h TOS post data

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -6,7 +6,7 @@ cask 'segger-jlink' do
       using: :post,
       data:  {
                'accept_license_agreement' => 'accepted',
-               'non_eu_denied_list'       => 'confirmed',
+               'non_emb_ctr'              => 'confirmed',
                'submit'                   => 'Download software',
              }
   name 'Segger J-Link Command Line Tools'


### PR DESCRIPTION
The post data has been changed. The change is fairly trivial.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).