### PR TITLE
Update wacom-tablet from 6.3.33-5 to 6.3.34-2

### DIFF
--- a/Casks/wacom-tablet.rb
+++ b/Casks/wacom-tablet.rb
@@ -1,6 +1,6 @@
 cask 'wacom-tablet' do
-  version '6.3.33-5'
-  sha256 'd1182d097f3d001d1e4e6749509bfa1df86a6a4b98d30b71f347d83d3051b238'
+  version '6.3.34-2'
+  sha256 'e4b40734864b93a4a85ac3970ef70cc6bcbb7854ed73d3ff4580d17e9a9324ce'
 
   url "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   appcast 'https://www.wacom.com/en-de/support/product-support/drivers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.