### PR TITLE
plantronics-hub caveat

### DIFF
--- a/Casks/plantronics-hub.rb
+++ b/Casks/plantronics-hub.rb
@@ -10,6 +10,13 @@ cask 'plantronics-hub' do
 
   pkg 'Plantronics Software.pkg'
 
+  def caveats
+    <<~EOS
+      This package installs a locally generated selfsigned certificate to the system trust.
+      This is installed as 'Plantronics Hub' and has FULL TRUST by default.
+    EOS
+  end
+
   uninstall pkgutil:   [
                          'com.plantronics.plantronicsSoftware.PlantronicsHub.pkg',
                          'com.plantronics.plantronicsSoftware.preflight.pkg',


### PR DESCRIPTION
Add caveat explaining that this installs a self-signed cert to the system trust.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.  Fails: unrelated to commit (url invalid?)
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. (N/A unversioned cask)
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version). N/A not a version update

