### PR TITLE
Update segger-jlink from 6.44h to 6.44i

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,12 +1,12 @@
 cask 'segger-jlink' do
-  version '6.44h'
-  sha256 '9fd8f216020d91ce41dfa093295681f81662bbf6b28711e60a70d89ceaa81d5c'
+  version '6.44i'
+  sha256 'f04fe7da71a774b67cadb7a383025036f218def8066b197a395a817beac81c45'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,
       data:  {
                'accept_license_agreement' => 'accepted',
-               'non_eu_denied_list'       => 'confirmed',
+               'non_emb_ctr'              => 'confirmed',
                'submit'                   => 'Download software',
              }
   name 'Segger J-Link Command Line Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.