### PR TITLE
Secure URLs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://www.contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://www.contributor-covenant.org/
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/Casks/apogee-one.rb
+++ b/Casks/apogee-one.rb
@@ -3,7 +3,7 @@ cask 'apogee-one' do
   sha256 'f99c06cf3ae7f9009a57cb35bafe803236fa55e1518ff48e55e55f16f62df80f'
 
   url "https://www.apogeedigital.com/drivers/one-#{version}.dmg"
-  appcast 'http://www.apogeedigital.com/support/register/one-ipad-mac'
+  appcast 'https://www.apogeedigital.com/support/register/one-ipad-mac'
   name 'Apogee One'
   homepage 'https://www.apogeedigital.com/products/one'
 

--- a/Casks/apogee-quartet.rb
+++ b/Casks/apogee-quartet.rb
@@ -3,7 +3,7 @@ cask 'apogee-quartet' do
   sha256 'c9db60f2cde152c12e1c619b01d5389221ce15e02fafc5fa3fb7f664c0c1e044'
 
   url "https://www.apogeedigital.com/drivers/quartet-#{version}.dmg"
-  appcast 'http://www.apogeedigital.com/support/register/quartet'
+  appcast 'https://www.apogeedigital.com/support/register/quartet'
   name 'Apogee Quartet'
   homepage 'https://www.apogeedigital.com/products/quartet'
 

--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -8,9 +8,9 @@ cask 'apogee-symphony-mkii' do
   end
 
   url "https://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
-  appcast 'http://www.apogeedigital.com/support/register/symphony-io-mk-ii'
+  appcast 'https://www.apogeedigital.com/support/register/symphony-io-mk-ii'
   name 'Apogee Symphony I/O MkII'
-  homepage 'http://www.apogeedigital.com/products/symphony-io'
+  homepage 'https://www.apogeedigital.com/products/symphony-io'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/apogee-symphony.rb
+++ b/Casks/apogee-symphony.rb
@@ -9,7 +9,7 @@ cask 'apogee-symphony' do
     url "https://www.apogeedigital.com/drivers/symphony-io-#{version}.dmg"
   end
 
-  appcast 'http://www.apogeedigital.com/support/register/symphony-io'
+  appcast 'https://www.apogeedigital.com/support/register/symphony-io'
   name 'Apogee Symphony I/O'
   homepage 'https://www.apogeedigital.com/support/symphony-io'
 

--- a/Casks/bose-updater.rb
+++ b/Casks/bose-updater.rb
@@ -18,6 +18,6 @@ cask 'bose-updater' do
   zap trash: '~/Library/Preferences/com.bose.Bose Updater.plist'
 
   caveats do
-    license 'http://btu.bose.com/#section=install'
+    license 'https://btu.bose.com/#section=install'
   end
 end

--- a/Casks/brother-p-touch-editor.rb
+++ b/Casks/brother-p-touch-editor.rb
@@ -4,7 +4,7 @@ cask 'brother-p-touch-editor' do
 
   url "https://download.brother.com/pub/com/ptouch-su/editor/pem#{version.no_dots}x14us.dmg"
   name 'Brother P-Touch Editor'
-  homepage 'http://www.brother.com/product/dev/label/editor/index.htm'
+  homepage 'https://www.brother.com/product/dev/label/editor/index.htm'
 
   pkg "BrotherPtEdit#{version.major}.pkg"
 

--- a/Casks/caldigit-thunderbolt-charging.rb
+++ b/Casks/caldigit-thunderbolt-charging.rb
@@ -2,9 +2,9 @@ cask 'caldigit-thunderbolt-charging' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.caldigit.com/Support/TS3/CalDigit-Thunderbolt-Station-Charging-Support.zip'
+  url 'https://archive.caldigit.com/Support/TS3/CalDigit-Thunderbolt-Station-Charging-Support.zip'
   name 'CalDigit Thunderbolt Station USB Charging & SuperDrive Support Driver'
-  homepage 'http://www.caldigit.com/support.asp'
+  homepage 'https://archive.caldigit.com/support.asp'
 
   pkg 'CalDigit Thunderbolt Station Charging Support.pkg'
 

--- a/Casks/caldigit-usb-c-dock-driver.rb
+++ b/Casks/caldigit-usb-c-dock-driver.rb
@@ -2,9 +2,9 @@ cask 'caldigit-usb-c-dock-driver' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.caldigit.com/support/USB-C-Dock-mac.zip'
+  url 'https://www.caldigit.com/support/USB-C-Dock-mac.zip'
   name 'CalDigit USB-C Dock Driver'
-  homepage 'http://www.caldigit.com/usb-3-1-usb-c-dock/faq.asp'
+  homepage 'https://archive.caldigit.com/usb-3-1-usb-c-dock/faq.asp'
 
   pkg 'USB-C-Dock-mac/CalDigit-USB-C-Dock-Ethernet-Driver.pkg'
   pkg 'USB-C-Dock-mac/CalDigit-USB-Hub-Support-Driver.pkg'

--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -2,8 +2,8 @@ cask 'garmin-basecamp' do
   if MacOS.version <= :sierra
     version '4.7.0'
     sha256 '43d2fcd3571fff70eeca2734c56e0aae0f982bc1a7019588bd55b883cc34b16c'
-    url "http://download.garmin.com/software/BaseCampforMacLegacyVersion_#{version.no_dots}.dmg"
-    appcast 'http://www8.garmin.com/support/download_details.jsp?id=4939'
+    url "https://download.garmin.com/software/BaseCampforMacLegacyVersion_#{version.no_dots}.dmg"
+    appcast 'https://www8.garmin.com/support/download_details.jsp?id=4939'
   else
     version '4.8.4'
     sha256 '8d3595428caa289a15177eb483937bcb5dfd3399746ffc09c59c698c6f5d68e5'

--- a/Casks/garmin-virb-edit.rb
+++ b/Casks/garmin-virb-edit.rb
@@ -2,7 +2,7 @@ cask 'garmin-virb-edit' do
   version '5.4.3'
   sha256 'b58d481a30f24c7a2b4b753020ebe25250debd6bcaccceaa59684a0799e004d2'
 
-  url "http://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
+  url "https://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
   name 'Garmin VIRB Edit'
   homepage 'https://buy.garmin.com/en-US/US/p/573412'
 

--- a/Casks/gutenprint.rb
+++ b/Casks/gutenprint.rb
@@ -2,10 +2,11 @@ cask 'gutenprint' do
   version '5.2.14'
   sha256 'b1a58df72e3719b48de3b802d7e5c5a4d7d355170d8a99a4c45458a2bf871cb9'
 
+  # downloads.sourceforge.net/gimp-print was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gimp-print/gutenprint-#{version.major_minor}/#{version}/gutenprint-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/gimp-print/rss'
   name 'Gutenprint'
-  homepage 'http://gimp-print.sourceforge.net/'
+  homepage 'https://gimp-print.sourceforge.io/'
 
   pkg "gutenprint-#{version}.pkg"
 

--- a/Casks/hdhomerun.rb
+++ b/Casks/hdhomerun.rb
@@ -3,7 +3,7 @@ cask 'hdhomerun' do
   sha256 '65135fc468bc4d3547fe714517ee00ef6841726bfa9580c810978ed634dfa983'
 
   url "https://download.silicondust.com/hdhomerun/hdhomerun_mac_#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://download.silicondust.com/hdhomerun/hdhomerun_mac.dmg'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.silicondust.com/hdhomerun/hdhomerun_mac.dmg'
   name 'HDHomeRun'
   homepage 'https://www.silicondust.com/support/downloads/'
 

--- a/Casks/hp-connectivity-kit.rb
+++ b/Casks/hp-connectivity-kit.rb
@@ -2,7 +2,7 @@ cask 'hp-connectivity-kit' do
   version '20181016'
   sha256 '0ab7e168e9b3106f04f93f67b6e02e4844743e765b7c26ec1e471e96dae48566'
 
-  url "ftp://ftp.hp.com/pub/calculators/Prime/HP_Prime_Connectivity_Kit_#{version}.dmg"
+  url "https://ftp.hp.com/pub/calculators/Prime/HP_Prime_Connectivity_Kit_#{version}.dmg"
   name 'HP Connectivity Kit'
   homepage 'https://www8.hp.com/us/en/campaigns/prime-graphing-calculator/overview.html'
 

--- a/LICENSE
+++ b/LICENSE
@@ -21,4 +21,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <http://unlicense.org>
+For more information, please refer to <https://unlicense.org/>

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Drivers have strict requirements regarding which versions of an operating system
 If you believe the upstream requirements are incorrect, please contact *them* and get them to correct the information on their page, at which point the cask requirements can also be updated.
 
 ## License
-[The Unlicense](http://unlicense.org/)
+[The Unlicense](https://unlicense.org/)


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---
```
13 files inspected, no offenses detected
```
```
==> Downloading https://www.apogeedigital.com/drivers/one-2.5.dmg
==> Downloading from https://apogeedigital.com/drivers/one-2.5.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-one'.
audit for apogee-one: passed
==> Downloading https://www.apogeedigital.com/drivers/quartet-2.5.dmg
==> Downloading from https://apogeedigital.com/drivers/quartet-2.5.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-quartet'.
audit for apogee-quartet: passed
==> Downloading https://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.3.1.dmg
==> Downloading from https://apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.3.1.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-symphony-mkii'.
audit for apogee-symphony-mkii: passed
==> Downloading https://www.apogeedigital.com/drivers/symphony-io-5.4.dmg
==> Downloading from https://apogeedigital.com/drivers/symphony-io-5.4.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-symphony'.
audit for apogee-symphony: passed
==> Downloading https://downloads.bose.com/ced/boseupdater/mac/BoseUpdater_5.0.0.2500.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'bose-updater'.
audit for bose-updater: passed
==> Downloading https://download.brother.com/pub/com/ptouch-su/editor/pem51110x14us.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'brother-p-touch-editor'.
audit for brother-p-touch-editor: passed
==> Downloading https://archive.caldigit.com/Support/TS3/CalDigit-Thunderbolt-Station-Charging-Support.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'caldigit-thunderbolt-charging', skipping verification.
audit for caldigit-thunderbolt-charging: passed
==> Downloading https://www.caldigit.com/support/USB-C-Dock-mac.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'caldigit-usb-c-dock-driver', skipping verification.
audit for caldigit-usb-c-dock-driver: passed
==> Downloading https://download.garmin.com/software/BaseCampforMac_484.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'garmin-basecamp'.
audit for garmin-basecamp: passed
==> Downloading https://download.garmin.com/software/VIRBEditforMac_543.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'garmin-virb-edit'.
audit for garmin-virb-edit: passed
==> Downloading https://downloads.sourceforge.net/gimp-print/gutenprint-5.2/5.2.14/gutenprint-5.2.14.dmg
==> Downloading from https://netcologne.dl.sourceforge.net/project/gimp-print/gutenprint-5.2/5.2.14/gutenprint-5.2.14.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'gutenprint'.
audit for gutenprint: passed
==> Downloading https://download.silicondust.com/hdhomerun/hdhomerun_mac_20190417.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'hdhomerun'.
audit for hdhomerun: passed
==> Downloading https://ftp.hp.com/pub/calculators/Prime/HP_Prime_Connectivity_Kit_20181016.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'hp-connectivity-kit'.
audit for hp-connectivity-kit: passed
```