### PR TITLE
Update openbci-gui from 4.1.0 to 4.1.2

### DIFF
--- a/Casks/openbci-gui.rb
+++ b/Casks/openbci-gui.rb
@@ -1,14 +1,14 @@
 cask 'openbci-gui' do
-  version '4.1.0'
-  sha256 'ff9dd9fda3f6f05289ccba5c028dfa819c47c46317fa0288abf1543207f0334c'
+  version '4.1.2'
+  sha256 '51d879478355a4bbda7e533d505ee02463f375d07f0ffab8ea371222fc091b40'
 
   # github.com/OpenBCI/OpenBCI_GUI was verified as official when first introduced to the cask
-  url "https://github.com/OpenBCI/OpenBCI_GUI/releases/download/v#{version}/application.macosx.zip"
+  url "https://github.com/OpenBCI/OpenBCI_GUI/releases/download/v#{version}/openbcigui_v#{version}_macosx.dmg"
   appcast 'https://github.com/OpenBCI/OpenBCI_GUI/releases.atom'
   name 'OpenBCI GUI'
   homepage 'https://openbci.com/'
 
-  app 'application.macosx/OpenBCI_GUI.app'
+  app 'OpenBCI_GUI.app'
 
   uninstall quit: [
                     'OpenBCI_GUI',
@@ -19,6 +19,7 @@ cask 'openbci-gui' do
                '~/Library/Application Support/OpenBCIHub',
                '~/Library/Logs/OpenBCIHub',
                '~/Library/Preferences/com.openbci.hub.plist',
+               '~/Library/Preferences/com.openbci.hub.helper.plist',
                '~/Library/Saved Application State/OpenBCI_GUI.savedState',
                '~/Library/Saved Application State/com.openbci.hub.savedState',
              ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.