### PR TITLE
Update segger-jlink from 6.46a to 6.46b

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.46a'
-  sha256 '562b0a8aa79fd67b043c1e188abe87c38d4429ee6196e517769e92ba96c3cd00'
+  version '6.46b'
+  sha256 'de9e38bbca2e79e10dc55ffd3b28c224d10fc8a388fdc65c685ae274bdde8281'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.