### PR TITLE
Update insta360-studio from 3.3.2_20190314 to 3.3.3,20190530

### DIFF
--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -1,8 +1,8 @@
 cask 'insta360-studio' do
-  version '3.3.2_20190314'
-  sha256 '251b9b7c60f23883eeaa2266e7c64e91b97e356634f22d0cdc91e119afe70a38'
+  version '3.3.3,20190530'
+  sha256 '877c3768b6698826d8e016a8de8d7ac89fb37d73a1c1e85cc3e812080d35b23c'
 
-  url "https://static.insta360.com/software/Studio/Mac/Insta360%20Studio%202019_Mac_#{version}.pkg"
+  url "https://static.insta360.com/software/Studio/Mac/Insta360%20Studio%202019_Mac_#{version.after_comma}__signed.pkg"
   name 'Insta360 Studio'
   homepage 'https://www.insta360.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.