### PR TITLE
Update bose-soundtouch from 21.0.3-2635-5a2f205,mr4_2018_63f87764 to 21.0.3-2635-5a2f205,st1_2019_95571ec9

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,5 +1,5 @@
 cask 'bose-soundtouch' do
-  version '21.0.3-2635-5a2f205,mr4_2018_63f87764'
+  version '21.0.3-2635-5a2f205,st1_2019_95571ec9'
   sha256 '967073b8d66effc2afdaf6fc157542812c07acc8e697534485bbefd6115858d3'
 
   # bose.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.