### PR TITLE
Update blackvue-viewer from 1.32,74331 to 1.33,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.32,74331'
-  sha256 '4f74a31e058fd55c635424606c698dfa2c91e52575ced58085e17be5e61b094f'
+  version '1.33,74331'
+  sha256 'bf15e4464ec335af4f3b2da892bfee8005dbcbc2b3e627e07010c80eda42dc51'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.