### PR TITLE
Update synology-drive from 1.1.4-10580 to 2.0.0,11044

### DIFF
--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -14,7 +14,7 @@ cask 'synology-drive' do
   uninstall quit:      [
                          'io.com.synology.CloudStationUI',
                          'com.synology.CloudStation',
-                       ], 
+                       ],
             pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'
 end

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -9,7 +9,7 @@ cask 'synology-drive' do
 
   auto_updates true
 
-  pkg 'Install Synology Drive.pkg'
+  pkg 'Install Synology Drive Client.pkg'
 
   uninstall quit:      'io.com.synology.CloudStationUI',
             pkgutil:   'com.synology.CloudStation',

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -1,9 +1,9 @@
 cask 'synology-drive' do
-  version '1.1.4-10580'
-  sha256 '6be8292b697f2fa7eaa3b3aab09cbb66ee7f73ca18b99cd20865bc32834b09af'
+  version '2.0.0,11044'
+  sha256 '39148b4d4d589bd7d92fdf79fd011a85e98c6b4cedcf30c4e1b308d8c4e3287f'
 
-  url "https://global.download.synology.com/download/Tools/SynologyDriveClient/#{version}/Mac/Installer/synology-drive-#{version.sub(%r{.*-}, '')}.dmg"
-  appcast 'https://www.synology.com/en-global/releaseNote/SynologyDriveClient'
+  url "https://global.download.synology.com/download/Tools/SynologyDriveClient/#{version.before_comma}-#{version.after_comma}/Mac/Installer/synology-drive-client-#{version.after_comma}.dmg"
+  appcast 'https://archive.synology.com/download/Tools/SynologyDriveClient/'
   name 'Synology Drive'
   homepage 'https://www.synology.com/'
 

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -11,7 +11,10 @@ cask 'synology-drive' do
 
   pkg 'Install Synology Drive Client.pkg'
 
-  uninstall quit:      'io.com.synology.CloudStationUI',
+  uninstall quit:      [
+                         'io.com.synology.CloudStationUI',
+                         'com.synology.CloudStation',
+                       ], 
             pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'
 end

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -13,6 +13,7 @@ cask 'synology-drive' do
 
   uninstall quit:      [
                          'io.com.synology.CloudStationUI',
+                         'com.synology.CloudStationUI',
                          'com.synology.CloudStation',
                        ],
             pkgutil:   'com.synology.CloudStation',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.