### PR TITLE
Update synology-surveillance-station-client from 1.2.4-0642 to 1.2.5-0659

### DIFF
--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -10,7 +10,7 @@ cask 'synology-surveillance-station-client' do
   pkg 'Install Synology Surveillance Station Client.pkg'
 
   uninstall launchctl: 'com.synology.svsclient-SurveillanceStationClient',
-            delete:    '/Applications/Surveillance Station Client.app',
+            delete:    '/Applications/Synology Surveillance Station Client.app',
             quit:      'com.synology.svsclient-SurveillanceStationClient',
             pkgutil:   [
                          'com.synology.svsclient-Live-View',

--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -7,7 +7,7 @@ cask 'synology-surveillance-station-client' do
   name 'Synology Surveillance Station Client'
   homepage 'https://www.synology.com/surveillance/'
 
-  pkg 'Install Surveillance Station Client.pkg'
+  pkg 'Install Synology Surveillance Station Client.pkg'
 
   uninstall launchctl: 'com.synology.svsclient-SurveillanceStationClient',
             delete:    '/Applications/Surveillance Station Client.app',

--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -1,9 +1,9 @@
 cask 'synology-surveillance-station-client' do
-  version '1.2.4-0642'
-  sha256 'ad4a2a95ea68df329f3b2809f169a35d70d0b5429367ccfa8495339abb5f4109'
+  version '1.2.5-0659'
+  sha256 'ca4a8f089e4df91899405a613d3b8b0655628e510ee6f16282ce3dd834f5dc80'
 
   url "https://global.download.synology.com/download/Tools/SurveillanceStationClient/#{version}/Mac/Synology%20Surveillance%20Station%20Client-#{version}.dmg"
-  appcast 'https://www.synology.com/releaseNote/SurveillanceStationClient'
+  appcast 'https://archive.synology.com/download/Tools/SurveillanceStationClient/'
   name 'Synology Surveillance Station Client'
   homepage 'https://www.synology.com/surveillance/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.