### PR TITLE
Add yubico-yubikey-manager 1.1.1 zap

### DIFF
--- a/Casks/yubico-yubikey-manager.rb
+++ b/Casks/yubico-yubikey-manager.rb
@@ -11,9 +11,13 @@ cask 'yubico-yubikey-manager' do
 
   pkg "yubikey-manager-qt-#{version}-mac.pkg"
 
-  uninstall quit:    [
-                       'com.yubico.ykman',
-                       'org.qt-project.Qt.*',
-                     ],
+  uninstall quit:    'com.yubico.ykman',
             pkgutil: 'com.yubico.ykman'
+
+  zap trash: [
+               '~/Library/Caches/Yubico/YubiKey Manager',
+               '~/Library/Preferences/com.org-yubico.YubiKey Manager.plist',
+               '~/Library/Saved Application State/com.yubico.ykman.savedState',
+             ],
+      rmdir: '~/Library/Caches/Yubico'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Removed the generic Qt framework to prevent accidentally quitting other Qt-based applications.