### PR TITLE
Revert yubico-authenticator from 4.3.6 to 4.3.6b

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,6 +1,6 @@
 cask 'yubico-authenticator' do
-  version '4.3.6'
-  sha256 'dcd92bb5dbd014cd96225bb6d7088b968697850033189ac977ed581afa95116b'
+  version '4.3.6b'
+  sha256 '4fff8785ab9422249c5514950cc0b6cdb32975fc3aafef3f6cba6eaeb5c9082d'
 
   url "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-#{version}-mac.pkg"
   appcast 'https://developers.yubico.com/yubioath-desktop/Release_Notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.