### PR TITLE
Update netgeargenie from 2.4.40,2018-12-14 to 2.4.42

### DIFF
--- a/Casks/netgeargenie.rb
+++ b/Casks/netgeargenie.rb
@@ -1,12 +1,12 @@
 cask 'netgeargenie' do
-  version '2.4.40,2018-12-14'
-  sha256 'eca8915c6a792f85b00786fc303c8f91a7809ccfa2ba72212417fff9243517b1'
+  version '2.4.42'
+  sha256 'c11c659e550cec0e4bdabfc03d9fed49ab9a92be14ee40e47119e291ba260699'
 
   url 'http://updates1.netgear.com/netgeargenie/mac/update/NETGEARGenieInstaller.dmg'
   name 'NETGEARGenie'
   homepage 'https://www.netgear.com/home/discover/apps/genie.aspx'
 
-  pkg "NETGEAR_Genie_Installer_#{version.before_comma}(#{version.after_comma}).pkg"
+  pkg "NETGEAR_Genie_Installer_#{version}.pkg"
 
   uninstall quit:    'com.yourcompany.NETGEARGenie',
             pkgutil: 'com.netgear.netgearGenie.NETGEARGenie.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.