### PR TITLE
Update lmsclients-squeezeplay from 7.8.0r1149 to 7.8.0r1163

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -1,6 +1,6 @@
 cask 'lmsclients-squeezeplay' do
-  version '7.8.0r1149'
-  sha256 '0228243841db135a4b2ce2e2a4aed297c3d6639f2aa51d04e723827613b45dab'
+  version '7.8.0r1163'
+  sha256 '81bdde79c67d6aea9e25be6d0021259a2a1f0a4a4bb3aa4ddae249d7ccc60eb3'
 
   # downloads.sourceforge.net/lmsclients was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lmsclients/SqueezePlay-x86_64-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.