### PR TITLE
Revert "Update synology-drive from 1.1.4-10580 to 2.0.0,11044"

### DIFF
--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -1,21 +1,17 @@
 cask 'synology-drive' do
-  version '2.0.0,11044'
-  sha256 '39148b4d4d589bd7d92fdf79fd011a85e98c6b4cedcf30c4e1b308d8c4e3287f'
+  version '1.1.4-10580'
+  sha256 '6be8292b697f2fa7eaa3b3aab09cbb66ee7f73ca18b99cd20865bc32834b09af'
 
-  url "https://global.download.synology.com/download/Tools/SynologyDriveClient/#{version.before_comma}-#{version.after_comma}/Mac/Installer/synology-drive-client-#{version.after_comma}.dmg"
-  appcast 'https://archive.synology.com/download/Tools/SynologyDriveClient/'
+  url "https://global.download.synology.com/download/Tools/SynologyDriveClient/#{version}/Mac/Installer/synology-drive-#{version.sub(%r{.*-}, '')}.dmg"
+  appcast 'https://www.synology.com/en-global/releaseNote/SynologyDriveClient'
   name 'Synology Drive'
   homepage 'https://www.synology.com/'
 
   auto_updates true
 
-  pkg 'Install Synology Drive Client.pkg'
+  pkg 'Install Synology Drive.pkg'
 
-  uninstall quit:      [
-                         'io.com.synology.CloudStationUI',
-                         'com.synology.CloudStationUI',
-                         'com.synology.CloudStation',
-                       ],
+  uninstall quit:      'io.com.synology.CloudStationUI',
             pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'
 end


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask-drivers#1004

sorry, but upon closer inspection it seems that synology-drive 2.0 is still in beta

its quite confusing since the listings in their 'archive' site lists this like any normal release. 

however both these sites
https://www.synology.com/en-global/releaseNote/SynologyDriveClient
https://www.synology.com/en-global/beta

indicate that 2.0.0 is still beta and 1.1.4 is still the latest. lets revert the update to 2.0.0 for the time being