### PR TITLE
Update nitrokey from 1.3.2 to 1.4

### DIFF
--- a/Casks/nitrokey.rb
+++ b/Casks/nitrokey.rb
@@ -1,9 +1,9 @@
 cask 'nitrokey' do
-  version '1.3.2'
-  sha256 'd6276f6e632625f90a3081251b44636bc0ff4a17e245f080fbd3d661c0eadb85'
+  version '1.4'
+  sha256 '80f6c95f5fa8320e4e323e1f4c11ac428ad4b731ae186891a4a66c7c056485f0'
 
   # github.com/Nitrokey/nitrokey-app was verified as official when first introduced to the cask
-  url "https://github.com/Nitrokey/nitrokey-app/releases/download/v#{version}/Nitrokey.App.dmg"
+  url "https://github.com/Nitrokey/nitrokey-app/releases/download/v#{version}/Nitrokey-App.dmg"
   appcast 'https://github.com/Nitrokey/nitrokey-app/releases.atom'
   name 'Nitrokey App'
   homepage 'https://www.nitrokey.com/download/macos'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.