### PR TITLE
Update xbox360-controller-driver-unofficial 0.16.11 uninstall

### DIFF
--- a/Casks/xbox360-controller-driver-unofficial.rb
+++ b/Casks/xbox360-controller-driver-unofficial.rb
@@ -12,7 +12,7 @@ cask 'xbox360-controller-driver-unofficial' do
   pkg 'Install360Controller.pkg'
 
   uninstall launchctl: 'com.mice.360Daemon',
-            quit:      'com.mice.-60Daemon', # This is not a typo.
+            quit:      'com.mice.-60Daemon', # '-60' is not a typo.
             kext:      [
                          'com.mice.Xbox360ControllerForceFeedback',
                          'com.mice.driver.Xbox360Controller',

--- a/Casks/xbox360-controller-driver-unofficial.rb
+++ b/Casks/xbox360-controller-driver-unofficial.rb
@@ -7,16 +7,19 @@ cask 'xbox360-controller-driver-unofficial' do
   name 'TattieBogle Xbox 360 Controller Driver (with improvements)'
   homepage 'https://github.com/360Controller/360Controller'
 
+  depends_on macos: '>= :el_capitan'
+
   pkg 'Install360Controller.pkg'
 
-  uninstall pkgutil:   'com.mice.pkg.Xbox360controller',
-            launchctl: 'com.mice.360Daemon',
+  uninstall launchctl: 'com.mice.360Daemon',
+            quit:      'com.mice.-60Daemon', # This is not a typo.
             kext:      [
                          'com.mice.Xbox360ControllerForceFeedback',
                          'com.mice.driver.Xbox360Controller',
                          'com.mice.driver.Wireless360Controller',
                          'com.mice.driver.WirelessGamingReceiver',
                        ],
+            pkgutil:   'com.mice.pkg.Xbox360controller',
             # Symlink to kext in /Library/Extensions is not removed
             # during :pkgutil phase of uninstall, so we delete it here.
             delete:    '/System/Library/Extensions/360Controller.kext'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

