### PR TITLE
Update synology-surveillance-station-client from 1.2.5-0659 to 1.2.6-0660

### DIFF
--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -1,6 +1,6 @@
 cask 'synology-surveillance-station-client' do
-  version '1.2.5-0659'
-  sha256 'ca4a8f089e4df91899405a613d3b8b0655628e510ee6f16282ce3dd834f5dc80'
+  version '1.2.6-0660'
+  sha256 'ae295e15dfa7f9449c5b90cd1d966b9ea1310fdfa9f7c63fe26a634ccd2fb98e'
 
   url "https://global.download.synology.com/download/Tools/SurveillanceStationClient/#{version}/Mac/Synology%20Surveillance%20Station%20Client-#{version}.dmg"
   appcast 'https://archive.synology.com/download/Tools/SurveillanceStationClient/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.