### PR TITLE
Update bose-soundtouch from 21.0.3-2635-5a2f205,st1_2019_95571ec9 to 22.0.2-2735-8ff3929,st1_2019_95571ec9

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,6 +1,6 @@
 cask 'bose-soundtouch' do
-  version '21.0.3-2635-5a2f205,st1_2019_95571ec9'
-  sha256 '967073b8d66effc2afdaf6fc157542812c07acc8e697534485bbefd6115858d3'
+  version '22.0.2-2735-8ff3929,st1_2019_95571ec9'
+  sha256 'd8ad127559f91e9ea9a793549434a47090cb77f6b53261778b54aa4a872c070c'
 
   url "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
   appcast "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/index.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.