### PR TITLE
Update segger-ozone from 2.62e to 2.62g

### DIFF
--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -1,6 +1,6 @@
 cask 'segger-ozone' do
-  version '2.62e'
-  sha256 '53c7f147ac9574a0a1b97f468e3bf6f81cbc41d29074068d9e7256ecead2dee7'
+  version '2.62g'
+  sha256 'aa9e53a6605e46881f6c8ca719e02b9e743206dee9a4b0962f6ef396a7ae523d'
 
   url "https://www.segger.com/downloads/jlink/Ozone_MacOSX_V#{version.no_dots}_Universal.pkg"
   name 'Ozone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.