### PR TITLE
Revert "Update wacom-intuos3-tablet from 6.3.15-3 to 6.3.34-2"

### DIFF
--- a/Casks/wacom-intuos3-tablet.rb
+++ b/Casks/wacom-intuos3-tablet.rb
@@ -1,6 +1,6 @@
 cask 'wacom-intuos3-tablet' do
-  version '6.3.34-2'
-  sha256 'e4b40734864b93a4a85ac3970ef70cc6bcbb7854ed73d3ff4580d17e9a9324ce'
+  version '6.3.15-3'
+  sha256 'eda52482d9c59bf93661ed3e333475d2039480ed9ce51cef70302e5dc8e3da58'
 
   url "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   name 'Wacom Intuos3 Tablet'
@@ -10,13 +10,7 @@ cask 'wacom-intuos3-tablet' do
 
   pkg 'Install Wacom Tablet.pkg'
 
-  uninstall launchctl: [
-                         'com.wacom.wacomtablet',
-                         'com.wacom.DataStoreMgr',
-                         'com.wacom.DisplayMgr',
-                         'com.wacom.UpdateHelper',
-                         'com.wacom.displayhelper',
-                       ],
+  uninstall launchctl: 'com.wacom.wacomtablet',
             quit:      [
                          'com.google.android.mtpagent',
                          'com.google.android.mtpviewer',


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask-drivers#1020

Looks like I made a mistake, the tablet I have is not the Intuos 3. The last version that the Intuos 3 supports is indeed 6.3.15-3.