### PR TITLE
Update yubico yubikey manager cask 1.1.2b

### DIFF
--- a/Casks/yubico-yubikey-manager.rb
+++ b/Casks/yubico-yubikey-manager.rb
@@ -1,6 +1,6 @@
 cask 'yubico-yubikey-manager' do
-  version '1.1.1'
-  sha256 '40e11dfe770f0bf6e3abc2ef7556463f5c6613eb11113c2a180c7ca66fd60583'
+  version '1.1.2b'
+  sha256 'E4DDCBA8585197902145039681AA746F96C01D02540455A069069C527A439F76'
 
   url "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-#{version}-mac.pkg"
   appcast 'https://github.com/Yubico/yubikey-manager-qt/releases.atom'

--- a/Casks/yubico-yubikey-manager.rb
+++ b/Casks/yubico-yubikey-manager.rb
@@ -1,6 +1,6 @@
 cask 'yubico-yubikey-manager' do
   version '1.1.2b'
-  sha256 'E4DDCBA8585197902145039681AA746F96C01D02540455A069069C527A439F76'
+  sha256 'e4ddcba8585197902145039681aa746f96c01d02540455a069069c527a439f76'
 
   url "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-#{version}-mac.pkg"
   appcast 'https://github.com/Yubico/yubikey-manager-qt/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Just updating this to the latest version from 
https://developers.yubico.com/yubikey-manager-qt/Releases/