### PR TITLE
Update kiibohd-configurator from 1.0.0 to 1.0.1

### DIFF
--- a/Casks/kiibohd-configurator.rb
+++ b/Casks/kiibohd-configurator.rb
@@ -1,6 +1,6 @@
 cask 'kiibohd-configurator' do
-  version '1.0.0'
-  sha256 '8591e8fd0a18f2a0a5c0a1022c126ddc5c5715ec8f5a7af3d9e756883e715e39'
+  version '1.0.1'
+  sha256 '3a791deb24cd9bdb4c12292d040effa3b9532083dd795aa2f8f968a1de1a7700'
 
   # github.com/kiibohd/configurator was verified as official when first introduced to the cask
   url "https://github.com/kiibohd/configurator/releases/download/v#{version}/kiibohd-configurator-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.