### PR TITLE
Update silicon-labs-vcp-driver from 5.1.0 to 5.2.0

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -4,7 +4,7 @@ cask 'silicon-labs-vcp-driver' do
     pkg 'Legacy MacVCP Driver/Silicon Labs VCP Driver.pkg'
   else
     version '5.2.0'
-    pkg '⁨Install CP210x VCP Driver.app⁩'
+    app '⁨Install CP210x VCP Driver.app⁩'
   end
 
   sha256 'a3feeef0088362710e66d1eaa48113bfb2286242fdbae584cb7dcdd19117a6a2'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -4,7 +4,7 @@ cask 'silicon-labs-vcp-driver' do
     pkg 'Legacy MacVCP Driver/Silicon Labs VCP Driver.pkg'
   else
     version '5.2.0'
-    pkg 'Silicon Labs VCP Driver.pkg'
+    pkg '⁨Install CP210x VCP Driver.app⁩'
   end
 
   sha256 'a3feeef0088362710e66d1eaa48113bfb2286242fdbae584cb7dcdd19117a6a2'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -3,11 +3,11 @@ cask 'silicon-labs-vcp-driver' do
     version '4.11.3'
     pkg 'Legacy MacVCP Driver/Silicon Labs VCP Driver.pkg'
   else
-    version '5.1.0'
+    version '5.2.0'
     pkg 'Silicon Labs VCP Driver.pkg'
   end
 
-  sha256 '278ad8f1444a55ce7e86229f8ce808403fe556cf44921c1419bb96cacaf377f1'
+  sha256 'a3feeef0088362710e66d1eaa48113bfb2286242fdbae584cb7dcdd19117a6a2'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -4,7 +4,7 @@ cask 'silicon-labs-vcp-driver' do
     pkg 'Legacy MacVCP Driver/Silicon Labs VCP Driver.pkg'
   else
     version '5.2.0'
-    app '⁨Install CP210x VCP Driver.app⁩'
+    installer manual: '⁨Install CP210x VCP Driver.app⁩'
   end
 
   sha256 'a3feeef0088362710e66d1eaa48113bfb2286242fdbae584cb7dcdd19117a6a2'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.