### PR TITLE
Update synology-photo-station-uploader from 1.4.4-091 to 1.4.5-093

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -7,7 +7,7 @@ cask 'synology-photo-station-uploader' do
   name 'Synology Photo Station Uploader'
   homepage 'https://www.synology.com/'
 
-  pkg "PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.pkg"
+  pkg "SynologyPhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.pkg"
 
   uninstall pkgutil:   'com.synology.photostationuploader.installer',
             quit:      'com.synology.PhotoStationUploader',

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,8 +1,8 @@
 cask 'synology-photo-station-uploader' do
-  version '1.4.4-091'
-  sha256 'f25e009170387720291570d3acfef048d9ee05477c5a0b207df965ddf924d4cb'
+  version '1.4.5-093'
+  sha256 '16191318254ad221f52fa1c2b6ed1509d9cc22349c3129935f717fca7f0d44f1'
 
-  url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
+  url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/SynologyPhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
   appcast 'https://archive.synology.com/download/Tools/PhotoStationUploader/'
   name 'Synology Photo Station Uploader'
   homepage 'https://www.synology.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.