### PR TITLE
Add steelseries-exactmouse-tool latest uninstall

### DIFF
--- a/Casks/steelseries-exactmouse-tool.rb
+++ b/Casks/steelseries-exactmouse-tool.rb
@@ -9,8 +9,11 @@ cask 'steelseries-exactmouse-tool' do
 
   app 'SteelSeries ExactMouse Tool.app'
 
+  uninstall quit:       'com.SteelSeries.SteelSeries-ExactMouse-Tool',
+            login_item: 'SteelSeries ExactMouse Tool'
+
   zap trash: [
-               '~/Library/Preferences/com.SteelSeries.SteelSeries-ExactMouse-Tool.plist',
                '~/Library/Caches/com.apple.helpd/Generated/com.SteelSeries.SteelSeries-ExactMouse-Tool.help',
+               '~/Library/Preferences/com.SteelSeries.SteelSeries-ExactMouse-Tool.plist',
              ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

