### PR TITLE
Update corsair-icue from 3.15.101 to 3.18.77

### DIFF
--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -1,6 +1,6 @@
 cask 'corsair-icue' do
-  version '3.15.101'
-  sha256 'bf24c74f341074216be1378db762723aa084abb02426accb1dacd21e75a1ccb1'
+  version '3.18.77'
+  sha256 '046f3e7220c45fb9647f1e1a468fabee91de9026b0ce329eaf5567e12919d882'
 
   url "https://downloads.corsair.com/Files/CUE/iCUE-#{version}-release.dmg"
   appcast 'http://forum.corsair.com/v3/showthread.php?t=182942'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.