### PR TITLE
Update synology-cloud-station-backup from 4.3.1-4437 to 4.3.2-4450

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -1,6 +1,6 @@
 cask 'synology-cloud-station-backup' do
-  version '4.3.1-4437'
-  sha256 'e1faf8be16ab3e39cf0efe086f5e3b746285b4aec970c1d8c25502cf820ca6ca'
+  version '4.3.2-4450'
+  sha256 '8adb2a853853d6106784570734c9739d684600890cd6b797d88dc2785e0b8b86'
 
   url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
   appcast 'https://archive.synology.com/download/Tools/CloudStationBackup/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.