### PR TITLE
Update wd-security from 2.1.1.61 to 2.1.1.71

### DIFF
--- a/Casks/wd-security.rb
+++ b/Casks/wd-security.rb
@@ -1,6 +1,6 @@
 cask 'wd-security' do
-  version '2.1.1.61'
-  sha256 'b6744537b81a4bfb27c23413e457ddf74864220734a59a0df5ee0e48d90de8f5'
+  version '2.1.1.71'
+  sha256 'fbdaae8ee533b8ef353919c0a2906a0c8115a57bd692db1d8841fcc64e9b65aa'
 
   url "https://downloads.wdc.com/wdapp/WD_Security_Standalone_Installer_Mac_#{version.dots_to_underscores}.zip"
   appcast 'https://support.wdc.com/downloads.aspx?p=158'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.