### PR TITLE
secure URLs

### DIFF
--- a/Casks/8bitdo-firmware-updater.rb
+++ b/Casks/8bitdo-firmware-updater.rb
@@ -5,7 +5,7 @@ cask '8bitdo-firmware-updater' do
   url "http://tools.8bitdo.com/8BitdoFirmwareUpdater/8BitDoFirmwareUpdaterV#{version}.zip"
   appcast 'http://tools.8bitdo.com/8BitdoFirmwareUpdater/appcast.xml'
   name '8BitDo Firmware Updater'
-  homepage 'http://8bitdo.com/'
+  homepage 'https://support.8bitdo.com/firmware-updater.html'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/apogee-one.rb
+++ b/Casks/apogee-one.rb
@@ -2,10 +2,10 @@ cask 'apogee-one' do
   version '2.5'
   sha256 'f99c06cf3ae7f9009a57cb35bafe803236fa55e1518ff48e55e55f16f62df80f'
 
-  url "https://www.apogeedigital.com/drivers/one-#{version}.dmg"
-  appcast 'http://www.apogeedigital.com/support/register/one-ipad-mac'
+  url "https://apogeedigital.com/drivers/one-#{version}.dmg"
+  appcast 'https://apogeedigital.com/support/register/one-ipad-mac'
   name 'Apogee One'
-  homepage 'https://www.apogeedigital.com/products/one'
+  homepage 'https://apogeedigital.com/products/one'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/apogee-quartet.rb
+++ b/Casks/apogee-quartet.rb
@@ -2,10 +2,10 @@ cask 'apogee-quartet' do
   version '2.5'
   sha256 'c9db60f2cde152c12e1c619b01d5389221ce15e02fafc5fa3fb7f664c0c1e044'
 
-  url "https://www.apogeedigital.com/drivers/quartet-#{version}.dmg"
-  appcast 'http://www.apogeedigital.com/support/register/quartet'
+  url "https://apogeedigital.com/drivers/quartet-#{version}.dmg"
+  appcast 'https://apogeedigital.com/support/register/quartet'
   name 'Apogee Quartet'
-  homepage 'https://www.apogeedigital.com/products/quartet'
+  homepage 'https://apogeedigital.com/products/quartet'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/apogee-symphony-mkii.rb
+++ b/Casks/apogee-symphony-mkii.rb
@@ -7,10 +7,10 @@ cask 'apogee-symphony-mkii' do
     sha256 'b65fbadca751721b22517faf8fc1a72b1c8b7b0a102fd515efe1e265c9917aa7'
   end
 
-  url "https://www.apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
-  appcast 'http://www.apogeedigital.com/support/register/symphony-io-mk-ii'
+  url "https://apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Release.#{version}.dmg"
+  appcast 'https://apogeedigital.com/support/register/symphony-io-mk-ii'
   name 'Apogee Symphony I/O MkII'
-  homepage 'http://www.apogeedigital.com/products/symphony-io'
+  homepage 'https://apogeedigital.com/products/symphony-io'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/apogee-symphony.rb
+++ b/Casks/apogee-symphony.rb
@@ -2,16 +2,16 @@ cask 'apogee-symphony' do
   if MacOS.version <= :el_capitan
     version '5.2'
     sha256 '50563eab6ce715981f2d06011bf7836c540bd48e2a3f411ed7e9557dc4545fce'
-    url "https://www.apogeedigital.com/drivers/Symphony_Release_#{version}.dmg"
+    url "https://apogeedigital.com/drivers/Symphony_Release_#{version}.dmg"
   else
     version '5.4'
     sha256 'a74ae84061c428a4e4735aecf13d265bb7fe1319d9ed99941fa969eeb5e3fa9e'
-    url "https://www.apogeedigital.com/drivers/symphony-io-#{version}.dmg"
+    url "https://apogeedigital.com/drivers/symphony-io-#{version}.dmg"
   end
 
-  appcast 'http://www.apogeedigital.com/support/register/symphony-io'
+  appcast 'https://apogeedigital.com/support/register/symphony-io'
   name 'Apogee Symphony I/O'
-  homepage 'https://www.apogeedigital.com/support/symphony-io'
+  homepage 'https://apogeedigital.com/support/symphony-io'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/bose-updater.rb
+++ b/Casks/bose-updater.rb
@@ -18,6 +18,6 @@ cask 'bose-updater' do
   zap trash: '~/Library/Preferences/com.bose.Bose Updater.plist'
 
   caveats do
-    license 'http://btu.bose.com/#section=install'
+    license 'https://btu.bose.com/#section=install'
   end
 end

--- a/Casks/brother-p-touch-editor.rb
+++ b/Casks/brother-p-touch-editor.rb
@@ -2,9 +2,10 @@ cask 'brother-p-touch-editor' do
   version '5.1.110'
   sha256 '237ef13b68a96d686e99e78214a75ce3aec5bbb7b4073f49c34cd494057c0081'
 
+  # download.brother.com was verified as official when first introduced to the cask
   url "https://download.brother.com/pub/com/ptouch-su/editor/pem#{version.no_dots}x14us.dmg"
   name 'Brother P-Touch Editor'
-  homepage 'http://www.brother.com/product/dev/label/editor/index.htm'
+  homepage 'https://www.brother.co.jp/eng/dev/print/other_editor/'
 
   pkg "BrotherPtEdit#{version.major}.pkg"
 

--- a/Casks/canon-eos-utility.rb
+++ b/Casks/canon-eos-utility.rb
@@ -5,7 +5,7 @@ cask 'canon-eos-utility' do
   # gdlp01.c-wss.com/gds/3/0200005443/01/eum3.8.20-installer.dmg.zip was verified as official when first introduced to the cask
   url 'http://gdlp01.c-wss.com/gds/3/0200005443/01/eum3.8.20-installer.dmg.zip'
   name 'Canon EOS Utility'
-  homepage 'https://www.usa.canon.com/internet/portal/us/home/support/self-help-center/eos-utility'
+  homepage 'https://asia.canon/en/support/0200584202/1'
 
   installer manual: "eum#{version}-installer.app"
 

--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -3,7 +3,7 @@ cask 'corsair-icue' do
   sha256 '046f3e7220c45fb9647f1e1a468fabee91de9026b0ce329eaf5567e12919d882'
 
   url "https://downloads.corsair.com/Files/CUE/iCUE-#{version}-release.dmg"
-  appcast 'http://forum.corsair.com/v3/showthread.php?t=182942'
+  appcast 'https://forum.corsair.com/v3/showthread.php?t=182942'
   name 'Corsair iCUE'
   homepage 'https://www.corsair.com/us/en/icue'
 

--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -2,8 +2,8 @@ cask 'garmin-basecamp' do
   if MacOS.version <= :sierra
     version '4.7.0'
     sha256 '43d2fcd3571fff70eeca2734c56e0aae0f982bc1a7019588bd55b883cc34b16c'
-    url "http://download.garmin.com/software/BaseCampforMacLegacyVersion_#{version.no_dots}.dmg"
-    appcast 'http://www8.garmin.com/support/download_details.jsp?id=4939'
+    url "https://download.garmin.com/software/BaseCampforMacLegacyVersion_#{version.no_dots}.dmg"
+    appcast 'https://www8.garmin.com/support/download_details.jsp?id=4939'
   else
     version '4.8.4'
     sha256 '8d3595428caa289a15177eb483937bcb5dfd3399746ffc09c59c698c6f5d68e5'

--- a/Casks/garmin-virb-edit.rb
+++ b/Casks/garmin-virb-edit.rb
@@ -2,7 +2,7 @@ cask 'garmin-virb-edit' do
   version '5.4.3'
   sha256 'b58d481a30f24c7a2b4b753020ebe25250debd6bcaccceaa59684a0799e004d2'
 
-  url "http://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
+  url "https://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
   name 'Garmin VIRB Edit'
   homepage 'https://buy.garmin.com/en-US/US/p/573412'
 

--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -2,8 +2,8 @@ cask 'loupedeck' do
   version '2.7.0'
   sha256 'e6f9909ef78ae6c9d24ebd2875d5cb3b46358bcc37043bb1267abf819af20305'
 
-  # loupedeck-software-release.s3.eu-north-1.amazonaws.com was verified as official when first introduced to the cask
-  url "https://loupedeck-software-release.s3.eu-north-1.amazonaws.com/Software_Release_Version_#{version.dots_to_underscores}/MacOs_#{version.dots_to_underscores}/Loupedeck.dmg"
+  # loupedeck-software-release.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://loupedeck-software-release.s3.amazonaws.com/Software_Release_Version_#{version.dots_to_underscores}/MacOs_#{version.dots_to_underscores}/Loupedeck.dmg"
   name 'Loupdeck'
   homepage 'https://loupedeck.com/'
 

--- a/Casks/wd-firmware-updater.rb
+++ b/Casks/wd-firmware-updater.rb
@@ -2,7 +2,7 @@ cask 'wd-firmware-updater' do
   version '4.0.0.13'
   sha256 '8fd449b79366bc6670b550cd4fd2ca5cc896b90ba29e54a8ce0f86d96ee6fbf2'
 
-  url 'http://download.wdc.com/fwupdater/Mac/WDFirmwareUpdater.zip'
+  url 'https://download.wdc.com/fwupdater/Mac/WDFirmwareUpdater.zip'
   appcast 'https://support.wdc.com/downloads.aspx?lang=en'
   name 'WD Firmware Updater'
   homepage 'https://support.wdc.com/downloads.aspx?lang=en'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
==> Downloading http://tools.8bitdo.com/8BitdoFirmwareUpdater/8BitDoFirmwareUpda
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask '8bitdo-firmware-updater'.
audit for 8bitdo-firmware-updater: passed

1 file inspected, no offenses detected
==> Downloading https://apogeedigital.com/drivers/one-2.5.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-one'.
audit for apogee-one: passed

1 file inspected, no offenses detected
==> Downloading https://apogeedigital.com/drivers/quartet-2.5.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-quartet'.
audit for apogee-quartet: passed

1 file inspected, no offenses detected
==> Downloading https://apogeedigital.com/drivers/SymphonyIOMkII_Thunderbolt_Rel
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-symphony-mkii'.
audit for apogee-symphony-mkii: passed

1 file inspected, no offenses detected
==> Downloading https://apogeedigital.com/drivers/symphony-io-5.4.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'apogee-symphony'.
audit for apogee-symphony: passed

1 file inspected, no offenses detected
==> Downloading https://downloads.bose.com/ced/boseupdater/mac/BoseUpdater_6.0.0
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'bose-updater'.
audit for bose-updater: passed

1 file inspected, no offenses detected
==> Downloading https://download.brother.com/pub/com/ptouch-su/editor/pem51110x1
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'brother-p-touch-editor'.
audit for brother-p-touch-editor: passed

1 file inspected, no offenses detected
==> Downloading http://gdlp01.c-wss.com/gds/2/0200005842/01/EU-Installset-M3.10.
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'canon-eos-utility'.
audit for canon-eos-utility: passed

1 file inspected, no offenses detected
==> Downloading https://downloads.corsair.com/Files/CUE/iCUE-3.18.77-release.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'corsair-icue'.
audit for corsair-icue: passed

1 file inspected, no offenses detected
==> Downloading https://download.garmin.com/software/BaseCampforMac_484.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'garmin-basecamp'.
audit for garmin-basecamp: passed

1 file inspected, no offenses detected
==> Downloading https://download.garmin.com/software/VIRBEditforMac_543.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'garmin-virb-edit'.
audit for garmin-virb-edit: passed

1 file inspected, no offenses detected
==> Downloading https://loupedeck-software-release.s3.amazonaws.com/Software_Rel
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'loupedeck'.
audit for loupedeck: passed

1 file inspected, no offenses detected
==> Downloading https://download.wdc.com/fwupdater/Mac/WDFirmwareUpdater.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'wd-firmware-updater'.
audit for wd-firmware-updater: passed
```
