### PR TITLE
change version stanza from 4.0.5230 to 4.0.5219 in  jabra-direct.rb

### DIFF
--- a/Casks/jabra-direct.rb
+++ b/Casks/jabra-direct.rb
@@ -1,5 +1,5 @@
 cask 'jabra-direct' do
-  version '4.0.5230'
+  version '4.0.5219'
   sha256 'efa10d4906f1b5e8c27c46bfeae6d6d2d5468bdc901352f1f4906bee71974588'
 
   # jabraxpressonlineprdstor.blob.core.windows.net/jdo was verified as official when first introduced to the cask


### PR DESCRIPTION
@reitermarkus - could we please fix this problem? The version number is wrong 
see: https://jabraexpressonlinejdo.jabra.com/jdo/jdo.json
4.0.5230 is the windows-version