### PR TITLE
Add zsa-wally v1.1.1

### DIFF
--- a/Casks/zsa-wally.rb
+++ b/Casks/zsa-wally.rb
@@ -1,0 +1,12 @@
+cask 'zsa-wally' do
+  version '1.1.1'
+  sha256 'd06c1270e9f369b3176d66b94a30b4d7f31c2a4c1c261926c7448ce3f270cf77'
+
+  # github.com/zsa/wally was verified as official when first introduced to the cask
+  url "https://github.com/zsa/wally/releases/download/#{version}-osx/wally-osx-#{version}.dmg"
+  appcast 'https://github.com/zsa/wally/releases.atom'
+  name 'Wally'
+  homepage 'https://ergodox-ez.com/pages/wally'
+
+  app 'Wally.app'
+end


### PR DESCRIPTION
Wally is an open source application allowing users to flash new firmwares to their ZSA keyboards.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
