### PR TITLE
Update casio-exam-mode-unlocker from 1.00,5 to 1.0.1,5

### DIFF
--- a/Casks/casio-exam-mode-unlocker.rb
+++ b/Casks/casio-exam-mode-unlocker.rb
@@ -1,8 +1,10 @@
 cask 'casio-exam-mode-unlocker' do
-  version '1.00,5'
-  sha256 '716f475829af3e737d5782552a49022aeba8622e177604ce5ccd5e0e70448af2'
+  version '1.0.1,5'
+  sha256 '1a78b0cd56c032a74f1a4805b408c6a3306cd09d690e083b48480091f0dc72ed'
 
   url "https://edu.casio.com/education/support_software/dl/exam_mode_unlocker/exammodeunlocker_inst_#{version.before_comma.no_dots}_#{version.after_comma}.zip"
+  appcast 'https://edu.casio.com/forteachers/er/software/',
+          configuration: version.before_comma.no_dots
   name 'Casio Exam Mode Unlocker'
   homepage 'https://edu.casio.com/education/support_software/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.