### PR TITLE
Update focusrite-control from 2.4.2 to 3.2.1_0

### DIFF
--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -9,9 +9,10 @@ cask 'focusrite-control' do
 
   pkg 'Focusrite Control.pkg'
 
-  uninstall pkgutil: [
-                       'com.focusrite.FocusriteControl',
-                       'com.focusrite.pkg.FocusritePCIe.audio_driver',
-                       'com.focusrite.pkg.FocusritePCIe.midi_driver',
-                     ]
+  uninstall pkgutil:   [
+                         'com.focusrite.FocusriteControl',
+                         'com.focusrite.pkg.FocusritePCIe.audio_driver',
+                         'com.focusrite.pkg.FocusritePCIe.midi_driver',
+                       ],
+            launchctl: 'com.focusrite.ControlServer'
 end

--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -1,8 +1,9 @@
 cask 'focusrite-control' do
-  version '2.4.2'
-  sha256 '6947d13533d591db0a8902ddee0f42e49ba73bf6819982a066be775bbcd54e08'
+  version '3.2.1_0'
+  sha256 '14c0ea0d2b27a34efd348509b704cc13d183f7ba7f427aea476eb372c05787bb'
 
-  url "https://customer.focusrite.com/sites/customer/files/downloads/Focusrite%20Control%20-%20#{version}.dmg"
+  url "https://customer.focusrite.com/sites/customer/files/downloads/Focusrite%20Control-#{version}.dmg"
+  appcast 'https://customer.focusrite.com/support/downloads?brand=Focusrite&product_by_type=1360&download_type=software'
   name 'Focusrite Control'
   homepage 'https://us.focusrite.com/downloads?product=Scarlett+18i8'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.