### PR TITLE
Update blackvue-viewer from 1.33,74331 to 1.34,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.33,74331'
-  sha256 'bf15e4464ec335af4f3b2da892bfee8005dbcbc2b3e627e07010c80eda42dc51'
+  version '1.34,74331'
+  sha256 '7ac72696720c196d327f32870a8324eafd3474731a2ee1f0478ef66262513bf1'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.