### PR TITLE
Update nordic-nrf-connect from 3.1.0 to 3.2.0

### DIFF
--- a/Casks/nordic-nrf-connect.rb
+++ b/Casks/nordic-nrf-connect.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-connect' do
-  version '3.1.0'
-  sha256 '504cd3f4b0fb095ef779b8e626a026d3f11304e862794355f009512536158175'
+  version '3.2.0'
+  sha256 '02ce74b1ba987fd1d842fd70b977238e5750a62135153f6a0c75b84517fd22d8'
 
   # github.com/NordicSemiconductor/pc-nrfconnect-core/ was verified as official when first introduced to the cask
   url "https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases/download/v#{version}/nrfconnect-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.