### PR TITLE
logitech-options: add multiple versions for macOS versions

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -1,13 +1,20 @@
 cask 'logitech-options' do
-  version '8.00.559'
-  sha256 '017468c89a2a85b78e78a17f0970cf179094a97fd748c831b42be61b0412c77a'
+  if MacOS.version <= :el_capitan
+    version '6.94.38'
+    sha256 '19ea1508517c9bd6504511890559f50a6ba1e92e283d4578a15312be79b4c8a1'
+  elsif MacOS.version <= :sierra
+    version '7.14.77'
+    sha256 'e4df55642e04139fc93d955e949bf736196a404ed067d87f8de7eb9ac9117ece'
+  else
+    version '8.00.559'
+    sha256 '017468c89a2a85b78e78a17f0970cf179094a97fd748c831b42be61b0412c77a'
+  end
 
   url "https://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"
   name 'Logitech Options'
   homepage 'https://support.logitech.com/software/options'
 
   auto_updates true
-  depends_on macos: '>= :sierra'
 
   pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
 

--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -1,8 +1,5 @@
 cask 'logitech-options' do
-  if MacOS.version <= :el_capitan
-    version '6.94.38'
-    sha256 '19ea1508517c9bd6504511890559f50a6ba1e92e283d4578a15312be79b4c8a1'
-  elsif MacOS.version <= :sierra
+  if MacOS.version <= :sierra
     version '7.14.77'
     sha256 'e4df55642e04139fc93d955e949bf736196a404ed067d87f8de7eb9ac9117ece'
   else
@@ -15,6 +12,7 @@ cask 'logitech-options' do
   homepage 'https://support.logitech.com/software/options'
 
   auto_updates true
+  depends_on macos: '>= :sierra'
 
   pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
I noticed the newest version (8.00.559) no longer supports Sierra. I added the latest supported versions for El Capitan (and previous), Sierra, and High Sierra and later. I was only able to confirmed it worked in Sierra (and CI should check for High Sierra).