### PR TITLE
Update xerox-print-driver from 4.25.0_2087 to 5.1.0_2110

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -8,8 +8,8 @@ cask 'xerox-print-driver' do
     sha256 '36b1ddf1f598ceaf6f91d38b0d228be3f8f6188c251761424cbea7a869488883'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1011/pt_BR/XeroxPrintDriver_#{version}.dmg"
   else
-    version '4.25.0_2087'
-    sha256 '2318799e3987266b2d7ce1130ac2739ca3f769b611d4ea18c57bf016c7567725'
+    version '5.1.0_2110'
+    sha256 'c82c03269eb6dc0f6fe0404128cd8786bf97212c825b30a83ae0d70cc1b469c7'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macos1012/pt_BR/XeroxPrintDriver_#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.