### PR TITLE
Update Loupedeck to v2.7.2

### DIFF
--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -9,7 +9,7 @@ cask 'loupedeck' do
 
   depends_on macos: '>= :sierra'
 
-  pkg "Loupedeck_#{version.dots_to_underscores}.pkg"
+  pkg "LoupedeckInstaller #{version}.pkg"
 
   uninstall signal:  [
                        ['TERM', 'com.loupedeck.Loupedeck2'],

--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -1,9 +1,9 @@
 cask 'loupedeck' do
-  version '2.7.0'
+  version '2.7.2'
   sha256 'e6f9909ef78ae6c9d24ebd2875d5cb3b46358bcc37043bb1267abf819af20305'
 
   # loupedeck-software-release.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://loupedeck-software-release.s3.amazonaws.com/Software_Release_Version_#{version.dots_to_underscores}/MacOs_#{version.dots_to_underscores}/Loupedeck.dmg"
+  url "https://loupedeck-software-release.s3.amazonaws.com/Software_Release_Mac_#{version.dots_to_underscores}/Loupedeck_#{version.dots_to_underscores}.dmg"
   name 'Loupdeck'
   homepage 'https://loupedeck.com/'
 

--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -1,6 +1,6 @@
 cask 'loupedeck' do
   version '2.7.2'
-  sha256 'e6f9909ef78ae6c9d24ebd2875d5cb3b46358bcc37043bb1267abf819af20305'
+  sha256 '91e87c9271dbf4a54d6cd533105b09e9de24839de5bfed17a6f6baa48699907e'
 
   # loupedeck-software-release.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://loupedeck-software-release.s3.amazonaws.com/Software_Release_Mac_#{version.dots_to_underscores}/Loupedeck_#{version.dots_to_underscores}.dmg"

--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -9,7 +9,7 @@ cask 'loupedeck' do
 
   depends_on macos: '>= :sierra'
 
-  pkg "Loupedeck Installer #{version}.pkg"
+  pkg "Loupedeck_#{version.dots_to_underscores}.pkg"
 
   uninstall signal:  [
                        ['TERM', 'com.loupedeck.Loupedeck2'],


### PR DESCRIPTION
Update Loupedeck driver package to v2.7.2 (latest stable version for MacOS).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
