### PR TITLE
Update ubiquiti-unifi-controller from 5.11.39 to 5.11.46

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'ubiquiti-unifi-controller' do
-  version '5.11.39'
-  sha256 'aa72791cd51bbfd429ab77cbb80f72307015ab239ef13f73087eddc136bc9159'
+  version '5.11.46'
+  sha256 '18252192fcb0fdd1162adbf44535eed39df79beaa2b621284fb79f9671fa3587'
 
   # dl.ubnt.com was verified as official when first introduced to the cask
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.