### PR TITLE
Update nvidia-web-driver from 387.10.10.10.40.130 to 387.10.10.10.40.131

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -9,8 +9,8 @@ cask 'nvidia-web-driver' do
     version '378.05.05.25f13'
     sha256 'f5849297ee8a4a754f26d998db83878d4c02324db00ec28ab38da1d847d7e5c1'
   else
-    version '387.10.10.10.40.130'
-    sha256 '214507c4d9e5daa3f30313084c0c0d33f1761827dbd5cae6ce05b845aa55afbc'
+    version '387.10.10.10.40.131'
+    sha256 '01435d41c1f246d830180e8533c7a94521c859e59d485b12978749f16714ecf0'
   end
 
   module Utils


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.