### PR TITLE
Update silicon-labs-vcp-driver to 5.2.1

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,6 +1,6 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.2.0'
-  sha256 'a3feeef0088362710e66d1eaa48113bfb2286242fdbae584cb7dcdd19117a6a2'
+  version '5.2.1'
+  sha256 '53f73af0866acd61a8b09d74db497694a3059458bd8be67c4546c2b0ea169681'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt'
@@ -10,14 +10,10 @@ cask 'silicon-labs-vcp-driver' do
 
   container nested: 'Mac_OSX_VCP_Driver/SiLabsUSBDriverDisk.dmg'
 
-  installer script: {
-                      executable: "#{staged_path}/Install CP210x VCP Driver.app/Contents/MacOS/Install CP210x VCP Driver",
-                      args:       ['-install'],
-                      sudo:       true,
-                    }
+  installer manual: 'Install CP210x VCP Driver.app'
 
   uninstall script: {
-                      executable: "#{staged_path}/uninstaller.sh",
+                      executable: 'uninstaller.sh',
                       sudo:       true,
                     }
 end


### PR DESCRIPTION
CP210x Macintosh OSX VCP Driver 5.2.1 - September 9, 2019
Fixes a problem with the installer that prevents it from working correctly with MacOS 10.15 Catalina.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
