### PR TITLE
Update segger-jlink from 6.52 to 6.52a

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.52'
-  sha256 'a17bafdcaa6494e63aac76768290a62cd88b392e000ba8ec78a8bc29f6563e4d'
+  version '6.52a'
+  sha256 'e7093fc0126f3bb54b1a231e7222dc333ee584352028e2957f4ec88d1003e70e'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.