### PR TITLE
Update synology-drive from 2.0.0-11050 to 2.0.1-11061

### DIFF
--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -15,7 +15,6 @@ cask 'synology-drive' do
                          'io.com.synology.CloudStationUI',
                          'com.synology.CloudStationUI',
                        ],
-
             pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'
 end

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -1,6 +1,6 @@
 cask 'synology-drive' do
-  version '2.0.0-11050'
-  sha256 '6b4228ce50b0151bb636653b42f02198ecab471de75defa19925d90abe9063c0'
+  version '2.0.1-11061'
+  sha256 '99d1dd5d6fd36c18e75fce0b038d3d2c3c5ad2132f95ca835450d052ab841634'
 
   url "https://global.download.synology.com/download/Tools/SynologyDriveClient/#{version}/Mac/Installer/synology-drive-client-#{version.sub(%r{.*-}, '')}.dmg"
   appcast 'https://archive.synology.com/download/Tools/SynologyDriveClient/'

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -11,7 +11,11 @@ cask 'synology-drive' do
 
   pkg 'Install Synology Drive Client.pkg'
 
-  uninstall quit:      'io.com.synology.CloudStationUI',
+  uninstall quit:      [
+                         'io.com.synology.CloudStationUI',
+                         'com.synology.CloudStationUI',
+                       ],
+
             pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.