### PR TITLE
Update silicon-labs-vcp-driver from 5.2.1 to 5.2.2

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,6 +1,6 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.2.1'
-  sha256 '53f73af0866acd61a8b09d74db497694a3059458bd8be67c4546c2b0ea169681'
+  version '5.2.2'
+  sha256 '281409987896c78e053eb6f0e10644f718f14cc0e2fa628678519f9144abf476'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -8,7 +8,7 @@ cask 'silicon-labs-vcp-driver' do
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'
 
-  container nested: 'Mac_OSX_VCP_Driver/SiLabsUSBDriverDisk.dmg'
+  container nested: 'Mac_OSX_VCP_Driver/Mac_OSX_VCP_Driver/SiLabsUSBDriverDisk.dmg'
 
   installer manual: 'Install CP210x VCP Driver.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.