### PR TITLE
Update blackvue-viewer from 1.34,74331 to 1.35,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.34,74331'
-  sha256 '7ac72696720c196d327f32870a8324eafd3474731a2ee1f0478ef66262513bf1'
+  version '1.35,74331'
+  sha256 '64b069f7d4ad2e3c70d5f721b4ddfd5f7902b458f352786c82f751056ac370a6'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.