### PR TITLE
Add Catalina support to DisplayLink (v5.2.1 Beta 2)

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -52,6 +52,7 @@ cask 'displaylink' do
                        ]
 
   caveats do
+    reboot
     license @cask.url.to_s
   end
 end

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -8,12 +8,12 @@ cask 'displaylink' do
   elsif MacOS.version <= :high_sierra
     version '4.3.1,1251'
     sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'
-  elsif MacOS.version == :catalina
-    version '5.2.1-beta.2,1433'
-    sha256 '7ad66ef562f19777caa332f5c75853aa7dcf6682be3ca3a35a012104f1de1888'
-  else
+  elsif MacOS.version <= :mojave
     version '5.2,1367'
     sha256 'dd9e5a900778c558c27994953052a7378d34e70d5163d6acf5f441d5785978f5'
+  else
+    version '5.2.1-beta.2,1433'
+    sha256 '7ad66ef562f19777caa332f5c75853aa7dcf6682be3ca3a35a012104f1de1888'
   end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",
@@ -27,11 +27,7 @@ cask 'displaylink' do
 
   pkg 'DisplayLink Software Installer.pkg'
 
-  uninstall pkgutil:   [
-                         'com.displaylink.displaylinkdriver',
-                         'com.displaylink.displaylinkdriversigned',
-                         'com.displaylink.displaylinkdriverunsigned',
-                       ],
+  uninstall pkgutil:   'com.displaylink.*',
             # 'kextunload -b com.displaylink.driver.DisplayLinkDriver' causes kernel panic
             # kext:      [
             #              'com.displaylink.driver.DisplayLinkDriver',

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -8,6 +8,9 @@ cask 'displaylink' do
   elsif MacOS.version <= :high_sierra
     version '4.3.1,1251'
     sha256 'd5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97'
+  elsif MacOS.version == :catalina
+    version '5.2.1-beta.2,1433'
+    sha256 '7ad66ef562f19777caa332f5c75853aa7dcf6682be3ca3a35a012104f1de1888'
   else
     version '5.2,1367'
     sha256 'dd9e5a900778c558c27994953052a7378d34e70d5163d6acf5f441d5785978f5'


### PR DESCRIPTION
Related closed PR on homebrew-cask-versions is https://github.com/Homebrew/homebrew-cask-versions/pull/7974.

After making all changes to the cask:

- [x] `brew cask audit --download Casks/displaylink.rb` is error-free.
- [x] `brew cask style --fix Casks/displaylink.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for ~[a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or~ a [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

- [x] `brew cask install Casks/displaylink.rb` worked successfully.
- [x] `brew cask uninstall Casks/displaylink.rb` worked successfully.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
