### PR TITLE
Update canon-pixma-scanner-driver-ica from 4.0.0a to 4.3.4a

### DIFF
--- a/Casks/canon-pixma-scanner-driver-ica.rb
+++ b/Casks/canon-pixma-scanner-driver-ica.rb
@@ -1,13 +1,13 @@
 cask 'canon-pixma-scanner-driver-ica' do
-  version '4.0.0a'
-  sha256 '4c6c7b1549b8c400addc5d2bd2454b01dc8cff567bb17e2343240d9cba201d6a'
+  version '4.3.4a'
+  sha256 '3433cd6dbdc3e4bb84c4c6bacadc6bb2c8630fc83e3fc49ce1dbd84c91b5765c'
 
   # gdlp01.c-wss.com/gds was verified as official when first introduced to the cask
-  url "http://gdlp01.c-wss.com/gds/7/0100006587/02/misd-mac-ijscanner1-#{version.dots_to_underscores.delete('^0-9_')}-ea19_2.dmg"
+  url "http://gdlp01.c-wss.com/gds/5/0100007645/04/misd-mac-ijscanner16f-#{version.dots_to_underscores.delete('^0-9_')}-ea21_3.dmg"
   name 'Canon PIXMA ICA Scanner Driver'
-  homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/printers/support-inkjet-printer/mg-series/pixma-mg6220'
+  homepage 'https://id.canon/en/support/0100764521/6/'
 
-  pkg "Canon IJScanner1_#{format('%02d' * 3, version.major, version.minor, version.patch)}.pkg"
+  pkg 'Canon IJScanner16f_040304.pkg'
 
-  uninstall pkgutil: "jp.co.canon.pkg.canonijscanner1.#{format('%02d' * 3, version.major, version.minor, version.patch)}"
+  uninstall pkgutil: 'jp.co.canon.pkg.canonijscanner16f.040304'
 end

--- a/Casks/canon-pixma-scanner-driver-ica.rb
+++ b/Casks/canon-pixma-scanner-driver-ica.rb
@@ -7,7 +7,7 @@ cask 'canon-pixma-scanner-driver-ica' do
   name 'Canon PIXMA ICA Scanner Driver'
   homepage 'https://id.canon/en/support/0100764521/6/'
 
-  pkg "Canon IJScanner16f_#{format('%02d' * 3, version.major, version.minor, version.patch)}.pkg"
+  pkg "Canon IJScanner16f_#{format('%<major>02d%<minor>02d%<patch>02d', major: version.major, minor: version.minor, patch: version.patch)}.pkg"
 
-  uninstall pkgutil: "jp.co.canon.pkg.canonijscanner16f.#{format('%02d' * 3, version.major, version.minor, version.patch)}"
+  uninstall pkgutil: "jp.co.canon.pkg.canonijscanner16f.#{format('%<major>02d%<minor>02d%<patch>02d', major: version.major, minor: version.minor, patch: version.patch)}"
 end

--- a/Casks/canon-pixma-scanner-driver-ica.rb
+++ b/Casks/canon-pixma-scanner-driver-ica.rb
@@ -5,7 +5,7 @@ cask 'canon-pixma-scanner-driver-ica' do
   # gdlp01.c-wss.com/gds was verified as official when first introduced to the cask
   url "http://gdlp01.c-wss.com/gds/5/0100007645/04/misd-mac-ijscanner16f-#{version.dots_to_underscores.delete('^0-9_')}-ea21_3.dmg"
   name 'Canon PIXMA ICA Scanner Driver'
-  homepage 'https://id.canon/en/support/0100764521/6/'
+  homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/printers/support-inkjet-printer/mg-series/pixma-mg6220'
 
   pkg "Canon IJScanner16f_#{format('%<major>02d%<minor>02d%<patch>02d', major: version.major, minor: version.minor, patch: version.patch)}.pkg"
 

--- a/Casks/canon-pixma-scanner-driver-ica.rb
+++ b/Casks/canon-pixma-scanner-driver-ica.rb
@@ -7,7 +7,7 @@ cask 'canon-pixma-scanner-driver-ica' do
   name 'Canon PIXMA ICA Scanner Driver'
   homepage 'https://id.canon/en/support/0100764521/6/'
 
-  pkg 'Canon IJScanner16f_040304.pkg'
+  pkg "Canon IJScanner16f_#{format('%02d' * 3, version.major, version.minor, version.patch)}.pkg"
 
-  uninstall pkgutil: 'jp.co.canon.pkg.canonijscanner16f.040304'
+  uninstall pkgutil: "jp.co.canon.pkg.canonijscanner16f.#{format('%02d' * 3, version.major, version.minor, version.patch)}"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.