### PR TITLE
Update bose-updater from 6.0.0.4388 to 6.0.0.4454

### DIFF
--- a/Casks/bose-updater.rb
+++ b/Casks/bose-updater.rb
@@ -1,6 +1,6 @@
 cask 'bose-updater' do
-  version '6.0.0.4388'
-  sha256 'eaa05106bfcdbda4d8989ffa02454ace6defc5c9b2ee04a3a14dad2bd0a567d4'
+  version '6.0.0.4454'
+  sha256 '4b19a953bb3d407f65e7c58fca8e53b9b087d7d38fd0e634f0dbd93003352efb'
 
   url "https://downloads.bose.com/ced/boseupdater/mac/BoseUpdater_#{version}.dmg"
   appcast 'https://btu.bose.com/data/MUV.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.