### PR TITLE
Update elgato-thunderbolt-dock from 1.2.9,130 to 1.2.10,131

### DIFF
--- a/Casks/elgato-thunderbolt-dock.rb
+++ b/Casks/elgato-thunderbolt-dock.rb
@@ -1,6 +1,6 @@
 cask 'elgato-thunderbolt-dock' do
-  version '1.2.9,130'
-  sha256 '00b378fc07d97237da361606ea088d5c19cf1d84c0c3829285abd2a7c8d5b866'
+  version '1.2.10,131'
+  sha256 'e76aff1d404451fa87d42c566475e83a09a15318cf33ad9219ed3792d5a7a098'
 
   url 'https://update.elgato.com/mac/thunderbolt-dock-update/download.php'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://update.elgato.com/mac/thunderbolt-dock-update/download.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.