### PR TITLE
Update displaylink to 5.2.1 Beta 3 for macOS Catalina

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -12,8 +12,8 @@ cask 'displaylink' do
     version '5.2,1367'
     sha256 'dd9e5a900778c558c27994953052a7378d34e70d5163d6acf5f441d5785978f5'
   else
-    version '5.2.1-beta.2,1433'
-    sha256 '7ad66ef562f19777caa332f5c75853aa7dcf6682be3ca3a35a012104f1de1888'
+    version '5.2.1-beta.3,1435'
+    sha256 '3bfa7d529a58bc20b6827857e644181376a71a16e2717eec71ea4fe496a8e236'
   end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for ~[a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or~ a [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
