### PR TITLE
Update xerox-print-driver from 5.1.0_2110 to 5.3.0_2118

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -7,10 +7,14 @@ cask 'xerox-print-driver' do
     version '4.17.1_1980'
     sha256 '36b1ddf1f598ceaf6f91d38b0d228be3f8f6188c251761424cbea7a869488883'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1011/pt_BR/XeroxPrintDriver_#{version}.dmg"
-  else
-    version '5.1.0_2110'
-    sha256 'c82c03269eb6dc0f6fe0404128cd8786bf97212c825b30a83ae0d70cc1b469c7'
+  elsif MacOS.version <= :sierra
+    version '5.2.0_2115'
+    sha256 '9989b6c127fca8c97b24bd86fd4d20035cd094c69e3fd41f6a243361f86483ec'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macos1012/pt_BR/XeroxPrintDriver_#{version}.dmg"
+  else
+    version '5.3.0_2118'
+    sha256 '3c6acc03416d1a31775fdbf4180982f12414fff14a91fa20db6716868b8643e8'
+    url "http://download.support.xerox.com/pub/drivers/BALTORO_HF/drivers/macOS10_13/pt_BR/XeroxPrintDriver_#{version}.dmg"
   end
 
   name 'Xerox Print Driver'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.