### PR TITLE
ubiquiti-unifi-controller: depend on java

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -35,6 +35,7 @@ cask 'ubiquiti-unifi-controller' do
              ]
 
   caveats do
+    depends_on_java '8'
     license 'https://www.ui.com/eula/'
   end
 end


### PR DESCRIPTION
As mentioned in the [release notes](https://community.ui.com/releases/UniFi-Network-Controller-5-12-22/263c8b60-def8-4667-85c3-87a6200a6c9b) (under *macOS Specific*):

> We stopped bundling Java as of UniFi Network 5.11.47. If you're installing that release or later please make sure you have manually installed a current release of Java 8 beforehand. Only the Java Runtime Environment (JRE) is required.