### PR TITLE
Update blackvue-viewer from 1.35,74331 to 1.36

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,8 +1,8 @@
 cask 'blackvue-viewer' do
-  version '1.35,74331'
-  sha256 '64b069f7d4ad2e3c70d5f721b4ddfd5f7902b458f352786c82f751056ac370a6'
+  version '1.36'
+  sha256 '66fd0f0929fbb3719b59783e445690a9c8ea60ae950aa68e48c249fa6feb1da0'
 
-  url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
+  url 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=74331'
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'
   name 'BlackVue Viewer'
   homepage 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.