### PR TITLE
secure URLs

### DIFF
--- a/Casks/bragi-updater.rb
+++ b/Casks/bragi-updater.rb
@@ -2,10 +2,10 @@ cask 'bragi-updater' do
   version '1.1.4'
   sha256 'ab3e12163bf4d73c641c1b249bc7a290d8eeb2034465d243b1e194f4e2f76f94'
 
-  url "http://update.bragi.com/bin/Bragi%20Updater-#{version}.dmg"
-  appcast 'http://update.bragi.com/scripts/scripts.36513c90.js'
+  url "https://update.bragi.com/bin/Bragi%20Updater-#{version}.dmg"
+  appcast 'https://update.bragi.com/scripts/scripts.36513c90.js'
   name 'Bragi Updater'
-  homepage 'http://update.bragi.com/'
+  homepage 'https://update.bragi.com/'
 
   app 'Bragi Updater.app'
 

--- a/Casks/canon-pixma-scanner-driver-ica.rb
+++ b/Casks/canon-pixma-scanner-driver-ica.rb
@@ -3,7 +3,7 @@ cask 'canon-pixma-scanner-driver-ica' do
   sha256 '3433cd6dbdc3e4bb84c4c6bacadc6bb2c8630fc83e3fc49ce1dbd84c91b5765c'
 
   # gdlp01.c-wss.com/gds was verified as official when first introduced to the cask
-  url "http://gdlp01.c-wss.com/gds/5/0100007645/04/misd-mac-ijscanner16f-#{version.dots_to_underscores.delete('^0-9_')}-ea21_3.dmg"
+  url "https://gdlp01.c-wss.com/gds/5/0100007645/04/misd-mac-ijscanner16f-#{version.dots_to_underscores.delete('^0-9_')}-ea21_3.dmg"
   name 'Canon PIXMA ICA Scanner Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/printers/support-inkjet-printer/mg-series/pixma-mg6220'
 

--- a/Casks/canon-ufrii-lt-printer-driver.rb
+++ b/Casks/canon-ufrii-lt-printer-driver.rb
@@ -3,7 +3,7 @@ cask 'canon-ufrii-lt-printer-driver' do
   sha256 '1d6c19b2234d4c42c731c4356fe89cc269929d5c0e9f97b06fdcc1454c5ba4c8'
 
   # gdlp01.c-wss.com/gds was verified as official when first introduced to the cask
-  url "http://gdlp01.c-wss.com/gds/1/0100010451/03/mac-UFRIILT-CARPS2LBP-v#{version.no_dots}-00.dmg"
+  url "https://gdlp01.c-wss.com/gds/1/0100010451/03/mac-UFRIILT-CARPS2LBP-v#{version.no_dots}-00.dmg"
   appcast 'https://my.canon/en/support/0101045101/3'
   name 'Canon UFRII LT Printer Driver'
   homepage 'https://my.canon/en/support/0101045101/3'

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -2,7 +2,7 @@ cask 'dymo-label' do
   version '8.7.3'
   sha256 '4a66168edfe253dae1e129fee48853d9e0e910416c61d746f1c0d42dddb838f0'
 
-  url "http://download.dymo.com/dymo/Software/Mac/DLS#{version.major}Setup.#{version}.dmg"
+  url "https://download.dymo.com/dymo/Software/Mac/DLS#{version.major}Setup.#{version}.dmg"
   appcast 'https://www.dymo.com/en-US/online-support'
   name 'Dymo Label'
   homepage 'https://www.dymo.com/en-US/online-support'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
==> Downloading https://update.bragi.com/bin/Bragi%20Updater-1.1.4.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'bragi-updater'.
audit for bragi-updater: passed

1 file inspected, no offenses detected
==> Downloading https://gdlp01.c-wss.com/gds/5/0100007645/04/misd-mac-ijscanner1
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'canon-pixma-scanner-driver-ica'.
audit for canon-pixma-scanner-driver-ica: passed

1 file inspected, no offenses detected
==> Downloading https://gdlp01.c-wss.com/gds/1/0100010451/03/mac-UFRIILT-CARPS2L
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'canon-ufrii-lt-printer-driver'.
audit for canon-ufrii-lt-printer-driver: passed

1 file inspected, no offenses detected
==> Downloading https://download.dymo.com/dymo/Software/Mac/DLS8Setup.8.7.3.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'dymo-label'.
audit for dymo-label: passed                                                                                                                                                                      ```
