### PR TITLE
Update corsair-icue from 3.20.80 to 3.22.74

### DIFF
--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -1,6 +1,6 @@
 cask 'corsair-icue' do
-  version '3.20.80'
-  sha256 '769d81554bbffdaefef7df677035d06bc8da8c15e16661e24c83580a99d03454'
+  version '3.22.74'
+  sha256 '27bbf2c00dbc51e2ce4c6860563def491fc790eff17c0b8934a8b16db476fd00'
 
   url "https://downloads.corsair.com/Files/CUE/iCUE-#{version}-release.dmg"
   appcast 'https://forum.corsair.com/v3/showthread.php?t=182942&page=999999999'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.