### PR TITLE
Update ubiquiti-unifi-controller from 5.12.22 to 5.12.35

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'ubiquiti-unifi-controller' do
-  version '5.12.22'
-  sha256 'a7873c0434178997b780c95738ae8ba9b1912360536c3c1be2652f374ae0cc6d'
+  version '5.12.35'
+  sha256 'd535d7831add7cd1870c0e102383a3af62c32ecc5c4895dcd383bee58b7a3385'
 
   # dl.ubnt.com was verified as official when first introduced to the cask
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.