### PR TITLE
Fix: URL for konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver

### DIFF
--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -2,7 +2,7 @@ cask 'konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver' do
   version '11.1.1'
   sha256 '1cfc8442928a08235d1a2a457192a4fb174490a656d1acea0c483b443fddb596'
 
-  url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=3381071352104e842f8efcdc14230488&tx_kmanacondaimport_downloadproxy[documentId]=1616&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
+  url 'https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=3381071352104e842f8efcdc14230488&tx_kmanacondaimport_downloadproxy[documentId]=1616&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685'
   name 'KONICA MINOLTA bizhub C759/C658/C368/C287/C3851 Series Printer'
   homepage 'https://www.konicaminolta.eu/en/business-solutions/support/download-center.html'
 

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -1,10 +1,12 @@
 cask 'konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver' do
-  version '11.1.1'
+  version '11.1.1,3381071352104e842f8efcdc14230488,1616,1558521685'
   sha256 '1cfc8442928a08235d1a2a457192a4fb174490a656d1acea0c483b443fddb596'
 
-  url 'https://o.cses.konicaminolta.com/file/Default.aspx?fileid=63586186-01F8-42A7-B7B1-65EFCDA41C04&filetype=DA'
+  url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=#{version.after_comma.before_comma}&tx_kmanacondaimport_downloadproxy[documentId]=#{version.after_comma.after_comma.before_comma}&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=#{version.after_comma.after_comma.after_comma}"
   name 'KONICA MINOLTA bizhub C759/C658/C368/C287/C3851 Series Printer'
-  homepage 'https://www.biz.konicaminolta.com/download/driver.html'
+  homepage 'https://www.konicaminolta.eu/en/business-solutions/support/download-center.html'
+
+  depends_on macos: '>= :mavericks'
 
   pkg 'Letter/C759_C658_C368_C287_C3851_109.pkg'
 

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -1,8 +1,8 @@
 cask 'konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver' do
-  version '11.1.1,3381071352104e842f8efcdc14230488,1616,1558521685'
+  version '11.1.1'
   sha256 '1cfc8442928a08235d1a2a457192a4fb174490a656d1acea0c483b443fddb596'
 
-  url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=#{version.after_comma.before_comma}&tx_kmanacondaimport_downloadproxy[documentId]=#{version.after_comma.after_comma.before_comma}&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=#{version.after_comma.after_comma.after_comma}"
+  url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=3381071352104e842f8efcdc14230488&tx_kmanacondaimport_downloadproxy[documentId]=1616&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
   name 'KONICA MINOLTA bizhub C759/C658/C368/C287/C3851 Series Printer'
   homepage 'https://www.konicaminolta.eu/en/business-solutions/support/download-center.html'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).