### PR TITLE
Update brother-p-touch-update-software from 1.5.1,14:dlfp100785 to 1.5.2,15:dlfp100785

### DIFF
--- a/Casks/brother-p-touch-update-software.rb
+++ b/Casks/brother-p-touch-update-software.rb
@@ -1,10 +1,10 @@
 cask 'brother-p-touch-update-software' do
-  version '1.5.1,14:dlfp100785'
-  sha256 'bd5f4f45033d9a3fb68a072b1cb001ea918e2091c1508f53c6c80c3977ef0849'
+  version '1.5.2,15:dlfp100785'
+  sha256 '7fac02d4d58c43ea029371bff75474536bb25a03687ff42ee7dc74cbb09591c8'
 
-  url "https://download.brother.com/welcome/#{version.after_colon}/pum#{version.before_comma.no_dots}ax#{version.after_comma.before_colon}all.dmg"
+  url "https://download.brother.com/welcome/#{version.after_colon}/pum#{version.before_comma.no_dots}x#{version.after_comma.before_colon}all.dmg"
   name 'Brother P-touch Update Software'
-  homepage 'https://support.brother.com/g/b/downloadhowto.aspx?c=us&lang=en&prod=lpql720nweus&os=10017&dlid=dlfp100352_000&flang=178&type3=10183'
+  homepage 'https://support.brother.com/'
 
   pkg 'BrotherPtUpdateSoftware.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.