### PR TITLE
konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb: add appcast

### DIFF
--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -3,6 +3,8 @@ cask 'konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver' do
   sha256 '1cfc8442928a08235d1a2a457192a4fb174490a656d1acea0c483b443fddb596'
 
   url 'https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=3381071352104e842f8efcdc14230488&tx_kmanacondaimport_downloadproxy[documentId]=1616&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=3381071352104e842f8efcdc14230488%26tx_kmanacondaimport_downloadproxy[documentId]=1616%26tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta%26tx_kmanacondaimport_downloadproxy[language]=EN%26type=1558521685',
+          configuration: version.no_dots
   name 'KONICA MINOLTA bizhub C759/C658/C368/C287/C3851 Series Printer'
   homepage 'https://www.konicaminolta.eu/en/business-solutions/support/download-center.html'
 


### PR DESCRIPTION
@core-code While testing in the browser, I noticed the `url` for this cask downloaded a file with a version number, making it a fit for `check_url_filename.cgi`. However, the script was giving me an error. Trying to debug it, the local script seemed to work fine while the CGI version was failing. Then it dawned on me that what happens is `cgi.FieldStorage()` is breaking up the download URL on its own `&`. The fix is to convert all `&` to `%26`, but that makes maintaining the `appcast` a bit worse (still better than not having an appcast).

Any idea on how we could improve the script to retain all functionality but not have to convert `&`? This cask isn’t popular, but it might become relevant for other casks.