### PR TITLE
Update silicon-labs-vcp-driver from 5.2.2 to 5.2.3

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,6 +1,6 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.2.2'
-  sha256 '281409987896c78e053eb6f0e10644f718f14cc0e2fa628678519f9144abf476'
+  version '5.2.3'
+  sha256 'a5d434b9c453646fd7cbc31fb3a9dd913a4d33d44deeaf9afb23a54941c27745'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.