### PR TITLE
behringer-x32-edit.rb: update links

### DIFF
--- a/Casks/behringer-x32-edit.rb
+++ b/Casks/behringer-x32-edit.rb
@@ -3,11 +3,12 @@ cask 'behringer-x32-edit' do
   version '4.1'
   sha256 '439f1d3d789958f4e44b53116d247363adf56aa62941dfadc0b0a6b4e458203d'
 
-  # downloads.music-group.com was verified as official when first introduced to the cask
-  url "https://downloads.music-group.com/software/behringer/X32/X32-Edit_MAC_#{version}.zip"
-  appcast 'https://www.behringer.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/Downloads'
+  # downloads.musictribe.com was verified as official when first introduced to the cask
+  url "https://downloads.musictribe.com/software/behringer/X32/X32-Edit_MAC_#{version}.zip"
+  appcast 'https://www.behringer.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/Downloads',
+          configuration: version.major_minor
   name 'Behringer X32-Edit'
-  homepage 'https://www.musictribe.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF'
+  homepage 'https://www.behringer.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/'
 
   app 'X32-Edit.app'
 
@@ -18,8 +19,4 @@ cask 'behringer-x32-edit' do
                '~/Library/Application Support/CrashReporter/X32-Edit_*.plist',
                '~/Library/Saved Application State/com.music-group.X32-Edit.savedState',
              ]
-
-  caveats do
-    license 'https://www.musictribe.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/downloads?active=Downloads'
-  end
 end

--- a/Casks/behringer-x32-edit.rb
+++ b/Casks/behringer-x32-edit.rb
@@ -5,8 +5,7 @@ cask 'behringer-x32-edit' do
 
   # downloads.musictribe.com was verified as official when first introduced to the cask
   url "https://downloads.musictribe.com/software/behringer/X32/X32-Edit_MAC_#{version}.zip"
-  appcast 'https://www.behringer.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/Downloads',
-          configuration: version.major_minor
+  appcast 'https://www.behringer.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/Downloads'
   name 'Behringer X32-Edit'
   homepage 'https://www.behringer.com/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/'
 


### PR DESCRIPTION
Redo of https://github.com/Homebrew/homebrew-cask-drivers/pull/1334.