### PR TITLE
Update qmk-toolbox from 0.0.14 to 0.0.15

### DIFF
--- a/Casks/qmk-toolbox.rb
+++ b/Casks/qmk-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'qmk-toolbox' do
-  version '0.0.14'
-  sha256 '3327a13c64824ef22edf9c9f1292958fef3fc01db59e676501ee249153439071'
+  version '0.0.15'
+  sha256 '4c6cce21d3989d07913801314d0174391998e362cf86ecd68418135d675bb646'
 
   # github.com/qmk/qmk_toolbox was verified as official when first introduced to the cask
   url "https://github.com/qmk/qmk_toolbox/releases/download/#{version}/QMK.Toolbox.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.