### PR TITLE
Update wacom-tablet from 6.3.38-2 to 6.3.38-3

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,9 +1,9 @@
 cask 'fujitsu-scansnap-home' do
-  version '1.5.0'
-  sha256 '3174cde65facffaa39ab6a1b564938711739809f72c7bdcd36621fde4202459e'
+  version '1.6.0'
+  sha256 '46d1ef801f233725111994b5d7b904003bb28932c49bdcb90a9eca200d29951c'
 
   # origin.pfultd.com was verified as official when first introduced to the cask
-  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg"
+  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
   name 'ScanSnap Home'
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 

--- a/Casks/wacom-tablet.rb
+++ b/Casks/wacom-tablet.rb
@@ -1,6 +1,6 @@
 cask 'wacom-tablet' do
-  version '6.3.38-2'
-  sha256 'b7ea1f65dd47e9f8d436107c0425b26a2339f7a94996bd4cc7f6b26225a79ceb'
+  version '6.3.38-3'
+  sha256 '6904c275ee398587436212ce44cc4d50a04ba186dd8ee596b5a51ef84fea6463'
 
   url "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   appcast 'https://www.wacom.com/en-de/support/product-support/drivers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.