### PR TITLE
Update segger-systemview from 2.52d to 3.10

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,9 +1,9 @@
 cask 'fujitsu-scansnap-home' do
-  version '1.5.0'
-  sha256 '3174cde65facffaa39ab6a1b564938711739809f72c7bdcd36621fde4202459e'
+  version '1.6.0'
+  sha256 '46d1ef801f233725111994b5d7b904003bb28932c49bdcb90a9eca200d29951c'
 
   # origin.pfultd.com was verified as official when first introduced to the cask
-  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg"
+  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
   name 'ScanSnap Home'
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 

--- a/Casks/segger-systemview.rb
+++ b/Casks/segger-systemview.rb
@@ -1,6 +1,6 @@
 cask 'segger-systemview' do
-  version '2.52d'
-  sha256 '652dcde70b4d6699d4a82aff9bcc1960e7053b18346299a150b835127549da02'
+  version '3.10'
+  sha256 '924dde978d72d36705bca7fd2a1cfddef6656ca2ca54dce7c6f17143d162773b'
 
   url "https://www.segger.com/downloads/jlink/SystemView_MacOSX_V#{version.no_dots}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/jlink/systemview_mac_pkg',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.