### PR TITLE
Update segger-systemview from 2.52d to 3.10

### DIFF
--- a/Casks/segger-systemview.rb
+++ b/Casks/segger-systemview.rb
@@ -1,6 +1,6 @@
 cask 'segger-systemview' do
-  version '2.52d'
-  sha256 '652dcde70b4d6699d4a82aff9bcc1960e7053b18346299a150b835127549da02'
+  version '3.10'
+  sha256 '0d941a82618067218d38d07fe3d42fbb98df09ca4cfacc619ec1091656017c88'
 
   url "https://www.segger.com/downloads/jlink/SystemView_MacOSX_V#{version.no_dots}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/jlink/systemview_mac_pkg',

--- a/Casks/segger-systemview.rb
+++ b/Casks/segger-systemview.rb
@@ -8,8 +8,7 @@ cask 'segger-systemview' do
   name 'SystemView'
   homepage 'https://www.segger.com/products/development-tools/systemview'
 
-  #pkg "SystemView_V#{version.no_dots}_MacOSX.pkg"
-  pkg 'fa08606d64c4aa29a4935e6c30074c969eee108ca517625e52bad554de19adb7--SystemView_V310_MacOSX.pkg'
+  pkg "SystemView_V#{version.no_dots}_MacOSX.pkg"
 
   uninstall pkgutil: 'com.segger.pkg.SystemView'
 end

--- a/Casks/segger-systemview.rb
+++ b/Casks/segger-systemview.rb
@@ -8,7 +8,8 @@ cask 'segger-systemview' do
   name 'SystemView'
   homepage 'https://www.segger.com/products/development-tools/systemview'
 
-  pkg "SystemView_V#{version.no_dots}_MacOSX.pkg"
+  #pkg "SystemView_V#{version.no_dots}_MacOSX.pkg"
+  pkg 'fa08606d64c4aa29a4935e6c30074c969eee108ca517625e52bad554de19adb7--SystemView_V310_MacOSX.pkg'
 
   uninstall pkgutil: 'com.segger.pkg.SystemView'
 end

--- a/Casks/segger-systemview.rb
+++ b/Casks/segger-systemview.rb
@@ -1,6 +1,6 @@
 cask 'segger-systemview' do
   version '3.10'
-  sha256 '0d941a82618067218d38d07fe3d42fbb98df09ca4cfacc619ec1091656017c88'
+  sha256 'e01926124fda21ebce31e9c5a7236e99e4902bfaa8e3ca313996af9bcdb28650'
 
   url "https://www.segger.com/downloads/jlink/SystemView_MacOSX_V#{version.no_dots}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/jlink/systemview_mac_pkg',

--- a/Casks/segger-systemview.rb
+++ b/Casks/segger-systemview.rb
@@ -1,14 +1,14 @@
 cask 'segger-systemview' do
   version '3.10'
-  sha256 'e01926124fda21ebce31e9c5a7236e99e4902bfaa8e3ca313996af9bcdb28650'
+  sha256 '6673e97b79f4a8adc717c8b967b53b8fd618c03b875d266368fcdc80e07e8d5e'
 
-  url "https://www.segger.com/downloads/jlink/SystemView_MacOSX_V#{version.no_dots}.pkg"
+  url 'https://www.segger.com/downloads/systemview/systemview_mac_pkg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/jlink/systemview_mac_pkg',
           configuration: version.no_dots
   name 'SystemView'
   homepage 'https://www.segger.com/products/development-tools/systemview'
 
-  pkg "SystemView_MacOSX_V#{version.no_dots}.pkg"
+  pkg "SystemView_V#{version.no_dots}_MacOSX.pkg"
 
   uninstall pkgutil: 'com.segger.pkg.SystemView'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.