### PR TITLE
Update wacom-tablet from 6.3.38-2 to 6.3.38-3

### DIFF
--- a/Casks/wacom-tablet.rb
+++ b/Casks/wacom-tablet.rb
@@ -1,6 +1,6 @@
 cask 'wacom-tablet' do
-  version '6.3.38-2'
-  sha256 'b7ea1f65dd47e9f8d436107c0425b26a2339f7a94996bd4cc7f6b26225a79ceb'
+  version '6.3.38-3'
+  sha256 '6904c275ee398587436212ce44cc4d50a04ba186dd8ee596b5a51ef84fea6463'
 
   url "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   appcast 'https://www.wacom.com/en-de/support/product-support/drivers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.