### PR TITLE
Update logitech-unifying to support Catalina

### DIFF
--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -17,6 +17,7 @@ cask 'logitech-unifying' do
                       :el_capitan,
                       :sierra,
                       :high_sierra,
+                      :catalina,
                     ]
 
   pkg 'Unifying Installer.app/Contents/Resources/Logitech Unifying Signed.mpkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Latest version (1.3.375) already supports Catalina, see [here](https://support.logi.com/hc/en-za/articles/360025297913) (click "Show All Downloads", choose "macOS 10.15" in the "Mac" drop-down and you'll see 1.3.375 available with "Compatibility with macOS Catalina" comment).