### PR TITLE
Update xerox-print-driver from 5.3.0_2118 to 5.4.2_2138

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -21,9 +21,9 @@ cask 'xerox-print-driver' do
   homepage 'https://www.support.xerox.com/support/colorqube-8570/downloads/'
 
   if MacOS.version <= :sierra
-    pkg "Xerox Print Driver #{version.major_minor_patch}.pkg"
+    pkg "Xerox Print Driver #{version.sub(/_.*/, '')}.pkg"
   else
-    pkg "Xerox Drivers #{version.major_minor_patch}.pkg"
+    pkg "Xerox Drivers #{version.sub(/_.*/, '')}.pkg"
   end
 
   uninstall launchctl: [

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -39,5 +39,6 @@ cask 'xerox-print-driver' do
             delete:    '/Library/Caches/Xerox',
             rmdir:     '/Library/Application Support/Xerox'
 
-  zap trash: '~/Library/Application Support/PowerENGAGE/XEROX'
+  zap pkgutil: 'com.xerox.drivers.pkg',
+      trash:   '~/Library/Application Support/PowerENGAGE/XEROX'
 end

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -21,9 +21,9 @@ cask 'xerox-print-driver' do
   homepage 'https://www.support.xerox.com/support/colorqube-8570/downloads/'
 
   if MacOS.version <= :sierra
-    pkg "Xerox Print Driver #{version.sub(/_.*/, '')}.pkg"
+    pkg "Xerox Print Driver #{version.sub(%r{_.*}, '')}.pkg"
   else
-    pkg "Xerox Drivers #{version.sub(/_.*/, '')}.pkg"
+    pkg "Xerox Drivers #{version.sub(%r{_.*}, '')}.pkg"
   end
 
   uninstall launchctl: [

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -12,15 +12,19 @@ cask 'xerox-print-driver' do
     sha256 '9989b6c127fca8c97b24bd86fd4d20035cd094c69e3fd41f6a243361f86483ec'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macos1012/pt_BR/XeroxPrintDriver_#{version}.dmg"
   else
-    version '5.3.0_2118'
-    sha256 '3c6acc03416d1a31775fdbf4180982f12414fff14a91fa20db6716868b8643e8'
-    url "http://download.support.xerox.com/pub/drivers/BALTORO_HF/drivers/macOS10_13/pt_BR/XeroxPrintDriver_#{version}.dmg"
+    version '5.4.2_2138'
+    sha256 '8b69dd93c07f8fe61a4e15bff49d3f1e5a41a669e84cd6b6f199187fa50b9eac'
+    url "http://download.support.xerox.com/pub/drivers/BALTORO_HF/drivers/macOS10_13/pt_BR/XeroxDrivers_#{version}.dmg"
   end
 
   name 'Xerox Print Driver'
   homepage 'https://www.support.xerox.com/support/colorqube-8570/downloads/'
 
-  pkg "Xerox Print Driver #{version.major_minor_patch}.pkg"
+  if MacOS.version <= :sierra
+    pkg "Xerox Print Driver #{version.major_minor_patch}.pkg"
+  else
+    pkg "Xerox Drivers #{version.major_minor_patch}.pkg"
+  end
 
   uninstall launchctl: [
                          'com.aviatainc.powerengage.XRTK',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.