### PR TITLE
Update geniatech-eyetv from 3.6.9_7528_20190730 to 4.0.0 (8518)

### DIFF
--- a/Casks/geniatech-eyetv.rb
+++ b/Casks/geniatech-eyetv.rb
@@ -4,7 +4,7 @@ cask 'geniatech-eyetv' do
 
   # file.geniatech.com/eyetv was verified as official when first introduced to the cask
   url "http://file.geniatech.com/eyetv#{version.major}/Geniatech_eyetv_#{version.major}.dmg"
-  appcast "http://updates.geniatech.eu/autoupdate/eyetv#{version.major}.rss?o=010014003"
+  appcast "http://updates.geniatech.eu/autoupdate/eyetv#{version.major}.rss"
   name 'EyeTV'
   homepage "https://www.geniatech.eu/product/eyetv-#{version.major}/"
 

--- a/Casks/geniatech-eyetv.rb
+++ b/Casks/geniatech-eyetv.rb
@@ -1,9 +1,9 @@
 cask 'geniatech-eyetv' do
-  version '3.6.9_7528_20190730'
-  sha256 '37db9f7f455f05074bdd20c36b01d73aed55cc48c2f871a17f91cf2580eb8b77'
+  version '4.0.0 (8518)'
+  sha256 '1178245beb0b234794320c55c6ed3405b6b875a86a46ea85cce62a801930399c'
 
-  # file.geniatech.com/eyetv3 was verified as official when first introduced to the cask
-  url "https://file.geniatech.com/eyetv3/EyeTV#{version}.dmg"
+  # file.geniatech.com/eyetv was verified as official when first introduced to the cask
+  url "http://file.geniatech.com/eyetv#{version.major}/Geniatech_eyetv_#{version.major}.dmg"
   appcast "http://updates.geniatech.eu/autoupdate/eyetv#{version.major}.rss?o=010014003"
   name 'EyeTV'
   homepage "https://www.geniatech.eu/product/eyetv-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.