### PR TITLE
Update logitech-control-center from 3.9.10 to 3.9.11

### DIFF
--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -3,6 +3,7 @@ cask 'logitech-control-center' do
   sha256 '18de9f8ae8461df57f6cc9e9f1f443674891ca94d71cb7d7dc0f4c94c32fb2c9'
 
   url "https://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
+  appcast 'https://support.logi.com/api/v2/help_center/en-us/articles.json'
   name 'Logitech Control Center'
   homepage 'https://support.logitech.com/en_us/product/3129'
 

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -1,6 +1,6 @@
 cask 'logitech-control-center' do
-  version '3.9.10'
-  sha256 'f2ee5d6a01009acc5b7da310695e1b9c0a0702814adc4e46e09023598e25721e'
+  version '3.9.11'
+  sha256 '18de9f8ae8461df57f6cc9e9f1f443674891ca94d71cb7d7dc0f4c94c32fb2c9'
 
   url "https://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
   name 'Logitech Control Center'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.