### PR TITLE
Update lg-onscreen-control from 3.52,hystR1EjmNPc1hNRcfKWg to 3.69,zBJAUHZ4JjNzO5UHojPoA

### DIFF
--- a/Casks/lg-onscreen-control.rb
+++ b/Casks/lg-onscreen-control.rb
@@ -7,7 +7,7 @@ cask 'lg-onscreen-control' do
   name 'LG OnScreen Control'
   homepage 'https://www.lg.com/us/support/monitors'
 
-  pkg "OSC_V#{version.before_comma}.pkg"
+  pkg "OSC_V#{version.before_comma}_signed.pkg"
 
   postflight do
     system_command '/bin/chmod',

--- a/Casks/lg-onscreen-control.rb
+++ b/Casks/lg-onscreen-control.rb
@@ -1,6 +1,6 @@
 cask 'lg-onscreen-control' do
-  version '3.52,hystR1EjmNPc1hNRcfKWg'
-  sha256 'a9ef5461ddaca25606024020e246372b1e52ba4f0e7a9c62f72874bfc07b6d91'
+  version '3.69,zBJAUHZ4JjNzO5UHojPoA'
+  sha256 '4ceaf3da93df82c5fa0062016f4a772eadf5c0468e65ea6bee95911e2b8414bd'
 
   # lge.com was verified as official when first introduced to the cask
   url "http://gscs-b2c.lge.com/downloadFile?fileId=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.