### PR TITLE
Update corsair-icue from 3.23.66 to 3.24.52

### DIFF
--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -1,6 +1,6 @@
 cask 'corsair-icue' do
-  version '3.23.66'
-  sha256 '0559dfaae141048dad8b7cfc6d08b467f564d7c53b3269a55763e540f767a710'
+  version '3.24.52'
+  sha256 'd00859903f9d0a2f231e39e33f9cedc41123e7c94d0ed28a7e6c3b26d8b78833'
 
   url "https://downloads.corsair.com/Files/CUE/iCUE-#{version}-release.dmg"
   appcast 'https://forum.corsair.com/v3/showthread.php?t=182942&page=999999999'

--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -3,7 +3,7 @@ cask 'corsair-icue' do
   sha256 'd00859903f9d0a2f231e39e33f9cedc41123e7c94d0ed28a7e6c3b26d8b78833'
 
   url "https://downloads.corsair.com/Files/CUE/iCUE-#{version}-release.dmg"
-  appcast 'https://forum.corsair.com/v3/showthread.php?t=182942&page=999999999'
+  appcast 'https://www.corsair.com/us/en/downloads/search?searchCategory=Cor_Products_iCue_Compatibility'
   name 'Corsair iCUE'
   homepage 'https://www.corsair.com/us/en/icue'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.