### PR TITLE
Corrected sha256 on fujitsu-scansnap-home

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,6 +1,6 @@
 cask 'fujitsu-scansnap-home' do
   version '1.6.0'
-  sha256 '46d1ef801f233725111994b5d7b904003bb28932c49bdcb90a9eca200d29951c'
+  sha256 'c0d4cfb208ceb0e2601f650073cf85883bd7ed3a31a6a225180c087d441a3163'
 
   # origin.pfultd.com was verified as official when first introduced to the cask
   url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
Fujitsu apparently changed the deployment package without changing its version number.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
