### PR TITLE
Update nordic-nrf-command-line-tools from 10.4.1 to 10.5.0

### DIFF
--- a/Casks/nordic-nrf-command-line-tools.rb
+++ b/Casks/nordic-nrf-command-line-tools.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-command-line-tools' do
-  version '10.4.1'
-  sha256 '204adc0bf84d39efd6f84d2c603f162db8e61f04eff43ac176c6183282133b52'
+  version '10.5.0'
+  sha256 '5683ad7684cf71868232008e707cf447bf22aea150068117e0b77076ec3e0fd8'
 
   url "https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-#{version.major}-x-x/nRF-Command-Line-Tools_#{version.dots_to_underscores}_OSX.tar"
   name 'nRF Command Line Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.