### PR TITLE
Update kyocera-printer-drivers from 5.0,2019.11.21 to 5.0a,2019.11.27

### DIFF
--- a/Casks/kyocera-printer-drivers.rb
+++ b/Casks/kyocera-printer-drivers.rb
@@ -1,8 +1,9 @@
 cask 'kyocera-printer-drivers' do
-  version '5.0,2019.11.21'
-  sha256 'a0a9ebbeb577a32c389f20bcd11af2b8094d04fa8acbe8cc73de444b102d0a4e'
+  version '5.0a,2019.11.27'
+  sha256 '022c1e9a710d157b4e68e4c0d5b519ca31280eb47c43296cdae6e92da864b41d'
 
-  url "https://www.kyoceradocumentsolutions.eu/content/download-center/eu/drivers/all/MacPhase#{version.before_comma.no_dots}_#{version.after_comma.dots_to_underscores}_zip.download.zip"
+  # kyostatics.net/dlc/eu/driver/all/ was verified as official when first introduced to the cask
+  url "https://cdn.kyostatics.net/dlc/eu/driver/all/kyocera_os_x_10_6.-downloadcenteritem-Single-File.downloadcenteritem.tmp/MacPhase#{version.before_comma.no_dots}_#{version.after_comma.dots_to_underscores}.zip"
   appcast 'https://dlc.kyoceradocumentsolutions.eu/index/service/dlc.false._.TASKALFA5053CI._.EN.html'
   name 'Kyocera Mac Driver'
   homepage 'https://dlc.kyoceradocumentsolutions.eu/index/service/dlc.false._.TASKALFA5053CI._.EN.html#MAC'

--- a/Casks/kyocera-printer-drivers.rb
+++ b/Casks/kyocera-printer-drivers.rb
@@ -9,7 +9,7 @@ cask 'kyocera-printer-drivers' do
   homepage 'https://dlc.kyoceradocumentsolutions.eu/index/service/dlc.false._.TASKALFA5053CI._.EN.html#MAC'
 
   depends_on macos: '>= :mavericks'
-  container nested: "Mac50_#{version.after_comma}-KDC/Kyocera OS X 10.9+ Web build #{version.after_comma}.dmg"
+  container nested: "Mac#{version.before_comma.no_dots}_#{version.after_comma}-KDC/Kyocera OS X 10.9+ Web build #{version.after_comma}.dmg"
 
   pkg "Kyocera OS X 10.9+ Web build #{version.after_comma}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.