### PR TITLE
Update logitech-options from 8.02.86 to 8.10.64

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -3,8 +3,8 @@ cask 'logitech-options' do
     version '7.14.77'
     sha256 'e4df55642e04139fc93d955e949bf736196a404ed067d87f8de7eb9ac9117ece'
   else
-    version '8.02.86'
-    sha256 'f4bc7a5d8709851acf5414e61a5930993923bf43d8a3931f64cd67cdef48d5b0'
+    version '8.10.64'
+    sha256 'f13a44149b3da9922412237b79fbc2323c63bb263f484f31a1e5d1fe9d2c3534'
   end
 
   url "https://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.