### PR TITLE
Update segger-jlink from 6.60d to 6.60e

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.60d'
-  sha256 'cd26da4957246ef4d59fb992bce189622cc9268bbdfdd0da7f58fc8f7c02f40a'
+  version '6.60e'
+  sha256 '9549b7446679715c62660c3723f9e102373d81c335cd99f725eb1ba9151b2d1a'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.