### PR TITLE
Update steelseries-engine from 3.17.1 to 3.17.2

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask 'steelseries-engine' do
-  version '3.17.1'
-  sha256 'e6205cf47d5c3570f82c7427d75f3c880217789af3506a8fbaaa5eebfa62db7b'
+  version '3.17.2'
+  sha256 'd1c3bc088cce2bbd86c5582fd9d017bd15140d175b3d4fb0f5d32f17d0dd3ab1'
 
   # steelseriescdn.com was verified as official when first introduced to the cask
   url "https://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.