### PR TITLE
Update geniatech-eyetv from 4.0.0 (8519) to 4.0.0 (8520)

### DIFF
--- a/Casks/geniatech-eyetv.rb
+++ b/Casks/geniatech-eyetv.rb
@@ -1,5 +1,5 @@
 cask 'geniatech-eyetv' do
-  version '4.0.0 (8519)'
+  version '4.0.0 (8520)'
   sha256 '3b6a195672e711f007f5c649b1092849f2e0187899f496d1359380e681ab1810'
 
   # file.geniatech.com/eyetv was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.