### PR TITLE
Update jabra-direct from 4.0.6206 to 4.0.6464

### DIFF
--- a/Casks/jabra-direct.rb
+++ b/Casks/jabra-direct.rb
@@ -1,6 +1,6 @@
 cask 'jabra-direct' do
-  version '4.0.6206'
-  sha256 'c89807ede6d1bfd314a377898ea5c2e0ab9991e5b39f6da260c1e4441ea3d659'
+  version '4.0.6464'
+  sha256 'b394f49913268cb950d4e0387f1091ae31d4aba24ebbb70e780f96bf1205919e'
 
   # jabraxpressonlineprdstor.blob.core.windows.net/jdo was verified as official when first introduced to the cask
   url 'https://jabraxpressonlineprdstor.blob.core.windows.net/jdo/JabraDirectSetup.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.