### PR TITLE
razer-synapse: Update website URL

### DIFF
--- a/Casks/razer-synapse.rb
+++ b/Casks/razer-synapse.rb
@@ -2,6 +2,7 @@ cask 'razer-synapse' do
   version '1.87.1'
   sha256 'a00fbbf1b4bb71717c1b552caf4465e16c715bc18a7e7160b4d046ba0ab5e0f4'
 
+  # dl.razerzone.com was verified as official when first introduced to the cask
   url "https://dl.razerzone.com/drivers/Synapse2/mac/Razer_Synapse_Mac_Driver_v#{version.major_minor}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://rzr.to/synapse-mac-download',
           configuration: version.major_minor

--- a/Casks/razer-synapse.rb
+++ b/Casks/razer-synapse.rb
@@ -6,7 +6,7 @@ cask 'razer-synapse' do
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://rzr.to/synapse-mac-download',
           configuration: version.major_minor
   name 'Razer Synapse'
-  homepage 'https://www.razerzone.com/synapse/'
+  homepage 'https://www.razer.com/synapse-2'
 
   depends_on macos: '>= :mavericks'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
```
$ brew cask audit --download Casks/razer-synapse.rb
==> Downloading https://dl.razerzone.com/drivers/Synapse2/mac/Razer_Synapse_Mac_Driver_v1.87.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'razer-synapse'.
audit for razer-synapse: passed
```
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
```
$ brew cask style --fix  Casks/razer-synapse.rb

1 file inspected, no offenses detected
```
- [ ] The commit message includes the cask’s name and version.
No. But the merge commit message can be changed. Is this a bocker?
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

razer has a release URL for synapse v3, which is only for Windows only, thus far

```bash
$ brew cask info razer-synapse
razer-synapse: 1.87.1
https://www.razerzone.com/synapse/
/usr/local/Caskroom/razer-synapse/1.87.1 (28.5MB)
From: https://github.com/Homebrew/homebrew-cask-drivers/blob/master/Casks/razer-synapse.rb
==> Name
Razer Synapse
==> Artifacts
Razer Synapse.pkg (Pkg)
==> Caveats
You must reboot for the installation of razer-synapse to take effect.
```
