### PR TITLE
Update hash of yubico-yubikey-manager

### DIFF
--- a/Casks/yubico-yubikey-manager.rb
+++ b/Casks/yubico-yubikey-manager.rb
@@ -1,6 +1,6 @@
 cask 'yubico-yubikey-manager' do
   version '1.1.4'
-  sha256 'f7ac99847c636f5cc250cd36dfc9b25b8fff73ebbf113a084a95f6e5feba3640'
+  sha256 '44690a9c6b80c422f46fed8172368c7f01e51218be066107f127095028d43b11'
 
   url "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-#{version}-mac.pkg"
   appcast 'https://github.com/Yubico/yubikey-manager-qt/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.

Not a new release but the current release hash has changed.

```
==> Upgrading 1 outdated package:
yubico-yubikey-manager 1.1.3 -> 1.1.4
==> Upgrading yubico-yubikey-manager
==> Downloading https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.1.4-mac.pkg
Already downloaded: /Users/dk/Library/Caches/Homebrew/downloads/65f4625d294556df2e07519bd3e8f1c41bf2f86bb735a7a4f36d21087bf5546e--yubikey-manager-qt-1.1.4-mac.pkg
Error: Checksum for Cask 'yubico-yubikey-manager' does not match.
Expected: f7ac99847c636f5cc250cd36dfc9b25b8fff73ebbf113a084a95f6e5feba3640
  Actual: 44690a9c6b80c422f46fed8172368c7f01e51218be066107f127095028d43b11
    File: /Users/dk/Library/Caches/Homebrew/downloads/65f4625d294556df2e07519bd3e8f1c41bf2f86bb735a7a4f36d21087bf5546e--yubikey-manager-qt-1.1.4-mac.pkg
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/master/doc/reporting_bugs/checksum_does_not_match_error.md
==> Verifying SHA-256 checksum for Cask 'yubico-yubikey-manager'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
==> Purging files for version 1.1.4 of Cask yubico-yubikey-manager
Installing yubico-yubikey-manager has failed!
Homebrew Bundle failed! 1 Brewfile dependency failed to install.
```

So I've changed the hash to match the release:

```
$ wget https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.1.4-mac.pkg
$ shasum -a 256 yubikey-manager-qt-1.1.4-mac.pkg 
44690a9c6b80c422f46fed8172368c7f01e51218be066107f127095028d43b11  yubikey-manager-qt-1.1.4-mac.pkg
