### PR TITLE
Update segger-ozone from 3.11a to 3.11b

### DIFF
--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -1,6 +1,6 @@
 cask 'segger-ozone' do
-  version '3.11a'
-  sha256 '08676ec2e23da87caa34de724561f3fafac32e8a130fae9b1d34db13f6a1ede6'
+  version '3.11b'
+  sha256 '9db45cec6f89fcecf3a2d684e91933f68c045fdcc1d545f2299c16a8a678e4b9'
 
   url "https://www.segger.com/downloads/jlink/Ozone_MacOSX_V#{version.no_dots}_Universal.pkg"
   appcast 'https://www.segger.com/downloads/jlink/ReleaseNotes_Ozone.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.