### PR TITLE
Update elgato-video-capture from 2.0.8701 to 2.0.2.8713_1762

### DIFF
--- a/Casks/elgato-video-capture.rb
+++ b/Casks/elgato-video-capture.rb
@@ -3,7 +3,7 @@ cask 'elgato-video-capture' do
   sha256 '87a5f0dd0c3fe091a0edcca98349137a4e7bda21524a3c4b776f3414e7c7cf90'
 
   url "https://edge.elgato.com/video-capture/macos/#{version.major_minor_patch}/final/Video_Capture_#{version}.zip"
-  appcast 'https://rink.hockeyapp.net/api/2/apps/651790b07f55248c266474ee243a733a.rss'
+  appcast 'https://www.elgato.com/sites/default/files/downloads.json'
   name 'Elgato Video Capture'
   homepage 'https://www.elgato.com/en/video-capture/'
 

--- a/Casks/elgato-video-capture.rb
+++ b/Casks/elgato-video-capture.rb
@@ -1,8 +1,8 @@
 cask 'elgato-video-capture' do
-  version '2.0.8701'
-  sha256 'dbb6b64143cf5954bdef1b9543b627bf482fe857cbeece0738bb3ca029fb47b9'
+  version '2.0.2.8713_1762'
+  sha256 '87a5f0dd0c3fe091a0edcca98349137a4e7bda21524a3c4b776f3414e7c7cf90'
 
-  url "https://edge.elgato.com/video-capture/macos/#{version.major_minor}/final/Elgato%20Video%20Capture%20#{version.major_minor}%20(#{version.patch}).dmg"
+  url "https://edge.elgato.com/video-capture/macos/#{version.major_minor_patch}/final/Video_Capture_#{version}.zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/651790b07f55248c266474ee243a733a.rss'
   name 'Elgato Video Capture'
   homepage 'https://www.elgato.com/en/video-capture/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.