### PR TITLE
Update corsair-icue from 3.24.52 to 3.25.60

### DIFF
--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -14,10 +14,13 @@ cask 'corsair-icue' do
   uninstall launchctl: [
                          'com.corsair.AudioConfigService.System',
                          'com.corsair.cue.3.launchHelper',
+                         'CorsairAudioConfigService (com.corsair.AudioConfigService.System)',
+                         'iCUELaunchAgent (com.corsair.cue.3.launchHelper)',
                        ],
             quit:      [
                          'com.corsair.cue.*',
                          'org.qt-project.*',
+                         'com.corsair.cue.3',
                        ],
             script:    [
                          executable: '/usr/bin/osascript',
@@ -27,6 +30,8 @@ cask 'corsair-icue' do
             pkgutil:   [
                          'com.corsair.CorsairAudio',
                          'com.corsair.cue.*',
+                         'com.corsair.CorsairAudio',
+                         'com.corsair.cue.3',
                        ],
             delete:    [
                          '/Library/Audio/Plug-Ins/HAL/CorsairAudio.plugin',

--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -14,13 +14,10 @@ cask 'corsair-icue' do
   uninstall launchctl: [
                          'com.corsair.AudioConfigService.System',
                          'com.corsair.cue.3.launchHelper',
-                         'CorsairAudioConfigService (com.corsair.AudioConfigService.System)',
-                         'iCUELaunchAgent (com.corsair.cue.3.launchHelper)',
                        ],
             quit:      [
                          'com.corsair.cue.*',
                          'org.qt-project.*',
-                         'com.corsair.cue.3',
                        ],
             script:    [
                          executable: '/usr/bin/osascript',
@@ -30,8 +27,6 @@ cask 'corsair-icue' do
             pkgutil:   [
                          'com.corsair.CorsairAudio',
                          'com.corsair.cue.*',
-                         'com.corsair.CorsairAudio',
-                         'com.corsair.cue.3',
                        ],
             delete:    [
                          '/Library/Audio/Plug-Ins/HAL/CorsairAudio.plugin',

--- a/Casks/corsair-icue.rb
+++ b/Casks/corsair-icue.rb
@@ -1,6 +1,6 @@
 cask 'corsair-icue' do
-  version '3.24.52'
-  sha256 'd00859903f9d0a2f231e39e33f9cedc41123e7c94d0ed28a7e6c3b26d8b78833'
+  version '3.25.60'
+  sha256 'f073a0baeb5615b9da75f3b7594af71b3d0c7f9a242b3fe7533cbc98488cf6f8'
 
   url "https://downloads.corsair.com/Files/CUE/iCUE-#{version}-release.dmg"
   appcast 'https://www.corsair.com/us/en/downloads/search?searchCategory=Cor_Products_iCue_Compatibility'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.