### PR TITLE
Update konica-minolta-bizhub-c554-c364-109-driver from 5.4.0 to 5.9.1

### DIFF
--- a/Casks/konica-minolta-bizhub-c554-c364-109-driver.rb
+++ b/Casks/konica-minolta-bizhub-c554-c364-109-driver.rb
@@ -6,7 +6,7 @@ cask 'konica-minolta-bizhub-c554-c364-109-driver' do
   name 'Konica Minolta Bizhub C554/C364 Postscript Printer Driver'
   homepage 'https://www.biz.konicaminolta.com/download/driver.html'
 
-  pkg 'C554_C364_Series_v5.9.1_A4/bizhub_C554_C364_109.pkg'
+  pkg "C554_C364_Series_v#{version}_A4/bizhub_C554_C364_109.pkg"
 
   uninstall pkgutil: 'jp.konicaminolta.print.package.C554'
 end

--- a/Casks/konica-minolta-bizhub-c554-c364-109-driver.rb
+++ b/Casks/konica-minolta-bizhub-c554-c364-109-driver.rb
@@ -1,12 +1,12 @@
 cask 'konica-minolta-bizhub-c554-c364-109-driver' do
-  version '5.4.0'
-  sha256 '5400c5c971baaccf1f5fdb67aef90a516faf07f39a195b00bb1f03126266ec21'
+  version '5.9.1'
+  sha256 'a62b85b5495fa3d4c47385089c7eb79f4c929a8f274934f8f8f0094c918f4b01'
 
-  url 'https://o.cses.konicaminolta.com/file/Default.aspx?fileid=2BECF238-AC0A-43BF-AC57-82E8E252A9BD&filetype=DA.dmg'
+  url 'https://p.knova.konicaminolta.com/PublicDownload/download?fileId=C39EEDB0-C408-473C-876F-222475A7D7AE'
   name 'Konica Minolta Bizhub C554/C364 Postscript Printer Driver'
   homepage 'https://www.biz.konicaminolta.com/download/driver.html'
 
-  pkg 'bizhub_C554_C364_109.pkg'
+  pkg 'C554_C364_Series_v5.9.1_A4/bizhub_C554_C364_109.pkg'
 
   uninstall pkgutil: 'jp.konicaminolta.print.package.C554'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.