### PR TITLE
Update apple-brother-printer-drivers

### DIFF
--- a/Casks/apple-brother-printer-drivers.rb
+++ b/Casks/apple-brother-printer-drivers.rb
@@ -2,7 +2,7 @@ cask 'apple-brother-printer-drivers' do
   version '4.1.1'
   sha256 '74dd579e43fb5b410d447e399bf33654adaefc01c968f8b61605ff48a41d9c2c'
 
-  # updates.cdn-apple.com/2019/cert/041-88742-20191011-c679d07b-a355-4dfa-bae5-70d692b3d0b2 was verified as official when first introduced to the cask
+  # updates.cdn-apple.com was verified as official when first introduced to the cask
   url 'https://updates.cdn-apple.com/2019/cert/041-88742-20191011-c679d07b-a355-4dfa-bae5-70d692b3d0b2/BrotherPrinterDrivers.dmg'
   appcast 'https://support.apple.com/downloads/brother'
   name 'Brother Printer Drivers'

--- a/Casks/apple-brother-printer-drivers.rb
+++ b/Casks/apple-brother-printer-drivers.rb
@@ -4,7 +4,7 @@ cask 'apple-brother-printer-drivers' do
 
   # updates.cdn-apple.com was verified as official when first introduced to the cask
   url 'https://updates.cdn-apple.com/2019/cert/041-88742-20191011-c679d07b-a355-4dfa-bae5-70d692b3d0b2/BrotherPrinterDrivers.dmg'
-  appcast 'https://support.apple.com/downloads/brother'
+  appcast 'https://support.apple.com/kb/DL1927'
   name 'Brother Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1927'
 

--- a/Casks/apple-brother-printer-drivers.rb
+++ b/Casks/apple-brother-printer-drivers.rb
@@ -1,8 +1,9 @@
 cask 'apple-brother-printer-drivers' do
   version '4.1.1'
-  sha256 '4f12496a351ecf2da717239c4c85a311401ddd465a036f4c175cfcc74abf58f6'
+  sha256 '74dd579e43fb5b410d447e399bf33654adaefc01c968f8b61605ff48a41d9c2c'
 
-  url "https://support.apple.com/downloads/DL1927/en_US/brotherprinterdrivers#{version}.dmg"
+  # updates.cdn-apple.com/2019/cert/041-88742-20191011-c679d07b-a355-4dfa-bae5-70d692b3d0b2 was verified as official when first introduced to the cask
+  url 'https://updates.cdn-apple.com/2019/cert/041-88742-20191011-c679d07b-a355-4dfa-bae5-70d692b3d0b2/BrotherPrinterDrivers.dmg'
   appcast 'https://support.apple.com/downloads/brother'
   name 'Brother Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1927'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The original download link no longer works.

The new link is the one found on https://support.apple.com/kb/DL1927