### PR TITLE
Update segger-jlink from 6.62b to 6.62c

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.62b'
-  sha256 '4389d9d67b6fcc04888ef4195b859398890d6d74e2679b86925a558fd0c13e95'
+  version '6.62c'
+  sha256 '0a6e980e315a25e5610e14c931ee94eb88615f039a1d2efce787a070eae3b4da'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.