### PR TITLE
Update blocks-code from 0.2.1 to 0.2.3

### DIFF
--- a/Casks/blocks-code.rb
+++ b/Casks/blocks-code.rb
@@ -1,6 +1,6 @@
 cask 'blocks-code' do
-  version '0.2.1'
-  sha256 'af9c68850f9a5f27e9eeed21e4372c2b8948213104ed9f96de07dab6315d90aa'
+  version '0.2.3'
+  sha256 '9d8d03f8f004bf5c5474e67065128d3c15806ed9594202596dbe1c094276943b'
 
   # assets.roli.com/blocks was verified as official when first introduced to the cask, ROLI is the company owning JUCE.
   url "https://assets.roli.com/blocks/BLOCKS+Code/#{version}/BLOCKSCodeInstallerOSX_v#{version}.mpkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.