### PR TITLE
Update dymo-label from 8.7.3 to 8.7.4

### DIFF
--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -1,6 +1,6 @@
 cask 'dymo-label' do
-  version '8.7.3'
-  sha256 '4a66168edfe253dae1e129fee48853d9e0e910416c61d746f1c0d42dddb838f0'
+  version '8.7.4'
+  sha256 '5d09fe70d39d9211c1c3e9f97379e182255ebf68b36e1c401f18b9671d6994e9'
 
   url "https://download.dymo.com/dymo/Software/Mac/DLS#{version.major}Setup.#{version}.dmg"
   appcast 'https://www.dymo.com/en-US/online-support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.