### PR TITLE
Update segger-jlink from 6.62d to 6.64

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.62d'
-  sha256 'bd27068dbff53dfbbd88778fd0e52bed783eeda11902d8303637dbcf3cc2ebb3'
+  version '6.64'
+  sha256 'a92220e78cffe36eee3b4b0d30f8a5e72c5df4ee766b3a4ed866374519ce6ec4'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.