### PR TITLE
Add Elektron Transfer 1.2.2.9

### DIFF
--- a/Casks/elektron-transfer.rb
+++ b/Casks/elektron-transfer.rb
@@ -3,6 +3,7 @@ cask 'elektron-transfer' do
   sha256 'e8940345dc4212f6d77cac5b61c1dd0147ad3e9d1d7aeb21e6c344ee0b8de3e5'
 
   url "https://www.elektron.se/wp-content/uploads/2018/03/Elektron_Transfer_#{version}_macOS.zip"
+  appcast 'https://www.elektron.se/support/?connection=transfer'
   name 'Elektron Transfer'
   homepage 'https://www.elektron.se/support/?connection=transfer#resources'
 

--- a/Casks/elektron-transfer.rb
+++ b/Casks/elektron-transfer.rb
@@ -6,5 +6,7 @@ cask 'elektron-transfer' do
   name 'Elektron Transfer'
   homepage 'https://www.elektron.se/support/?connection=transfer#resources'
 
+  depends_on macos: '>= :el_capitan'
+
   app 'Transfer.app'
 end

--- a/Casks/elektron-transfer.rb
+++ b/Casks/elektron-transfer.rb
@@ -1,0 +1,10 @@
+cask 'elektron-transfer' do
+  version '1.2.2.9'
+  sha256 'e8940345dc4212f6d77cac5b61c1dd0147ad3e9d1d7aeb21e6c344ee0b8de3e5'
+
+  url "https://www.elektron.se/wp-content/uploads/2018/03/Elektron_Transfer_#{version}_macOS.zip"
+  name 'Elektron Transfer'
+  homepage 'https://www.elektron.se/support/?connection=transfer#resources'
+
+  app 'Transfer.app'
+end


### PR DESCRIPTION
Elektron Transfer is a tool to transfer samples, presets and firmware
updates to Elektron Music Machines syntesizers, samplers etc.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].

Instead of overly `transfer` I used `elektron-transfer` token to mimic other formulas in this repo, majority includes vendor name, some do that even if app name does not do that.

- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-drivers/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
