### PR TITLE
Update asix-ax88179 from 2.15.0 to 2.16.0

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -7,8 +7,8 @@ cask 'asix-ax88179' do
 
     container nested: "AX88179_178A_macintosh_Driver_Installer_v#{version}/AX88179_178A.dmg"
   else
-    version '2.15.0'
-    sha256 '17ae7031bd8e9ffb5cfea9ee17dcd4e32b38297a6241a5c9c2ac0589fe5dfcca'
+    version '2.16.0'
+    sha256 'afe9d8563a5d8eeacb81857e2afc26162f63727750b97cdd434322e664f09db0'
 
     url "https://www.asix.com.tw/FrootAttach/driver/AX88179_178A_macOS_10.15_above_Driver_Installer_v#{version}.zip"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.