### PR TITLE
Update segger-jlink from 6.64 to 6.64a

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.64'
-  sha256 'a92220e78cffe36eee3b4b0d30f8a5e72c5df4ee766b3a4ed866374519ce6ec4'
+  version '6.64a'
+  sha256 '030bbc83fc063104176d337885d69c2a519f3685e3965c7711b0cc856c4483c1'
 
   url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.