### PR TITLE
Update fujitsu-scansnap-home from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -3,7 +3,7 @@ cask 'fujitsu-scansnap-home' do
   sha256 '8995fb4c000deaed2cdcf1dce347bdd95a79f275dd3a60695e72771efd417c63'
 
   # origin.pfultd.com was verified as official when first introduced to the cask
-  url "https://origin.pfultd.com/downloads/IMAGE/driver/ss/inst2/ix1500/m-software/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"
+  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
   name 'ScanSnap Home'
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 

--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -8,7 +8,7 @@ cask 'fujitsu-scansnap-home' do
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 
   depends_on macos: '>= :sierra'
-  container nested: "Download/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"
+  container nested: "Download/SSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
 
   pkg 'ScanSnap Home.pkg'
 

--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -8,7 +8,7 @@ cask 'fujitsu-scansnap-home' do
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 
   depends_on macos: '>= :sierra'
-  
+
   installer manual: 'ScanSnap Home Setup.app'
 
   uninstall launchctl: [

--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -9,7 +9,7 @@ cask 'fujitsu-scansnap-home' do
 
   depends_on macos: '>= :sierra'
 
-  installer manual: 'ScanSnap Home Setup.app'
+  installer manual: 'SSHDownloadInstaller.app'
 
   uninstall launchctl: [
                          'com.fujitsu.pfu.SshRegister',

--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,9 +1,9 @@
 cask 'fujitsu-scansnap-home' do
-  version '1.6.0'
-  sha256 'c0d4cfb208ceb0e2601f650073cf85883bd7ed3a31a6a225180c087d441a3163'
+  version '1.7.0'
+  sha256 '8995fb4c000deaed2cdcf1dce347bdd95a79f275dd3a60695e72771efd417c63'
 
   # origin.pfultd.com was verified as official when first introduced to the cask
-  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg"
+  url "https://origin.pfultd.com/downloads/ss/sshinst/m-170/MacSSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
   name 'ScanSnap Home'
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 

--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -3,14 +3,13 @@ cask 'fujitsu-scansnap-home' do
   sha256 '8995fb4c000deaed2cdcf1dce347bdd95a79f275dd3a60695e72771efd417c63'
 
   # origin.pfultd.com was verified as official when first introduced to the cask
-  url "https://origin.pfultd.com/downloads/ss/sshinst/m-170/MacSSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
+  url "https://origin.pfultd.com/downloads/IMAGE/driver/ss/inst2/ix1500/m-software/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"
   name 'ScanSnap Home'
   homepage 'https://www.fujitsu.com/global/products/computing/peripheral/scanners/scansnap/software/sshome/index.html'
 
   depends_on macos: '>= :sierra'
-  container nested: "Download/SSHDownloadInstaller_#{version.dots_to_underscores}.dmg"
-
-  pkg 'ScanSnap Home.pkg'
+  
+  installer manual: 'ScanSnap Home Setup.app'
 
   uninstall launchctl: [
                          'com.fujitsu.pfu.SshRegister',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.