### PR TITLE
Update acs-acr39u-smartcard-driver from 1.1.6.3 to 1.1.8

### DIFF
--- a/Casks/acs-acr39u-smartcard-driver.rb
+++ b/Casks/acs-acr39u-smartcard-driver.rb
@@ -1,6 +1,6 @@
 cask 'acs-acr39u-smartcard-driver' do
-  version '1.1.6.3'
-  sha256 'b3b8e9a3e4393953d2e1671b5baef6953d531599b5977b8a7d2b314d18b2af4a'
+  version '1.1.8'
+  sha256 'f1234d75178d892a133a410355a5a990cf75d2f33eba25d575943d4df632f3a4'
 
   url "https://www.acs.com.hk/download-driver-unified/10954/ACS-Unified-INST-MacOSX-#{version.no_dots}-P.zip"
   appcast 'https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.