### PR TITLE
Update nordic-nrf-connect from 3.3.0 to 3.3.1

### DIFF
--- a/Casks/nordic-nrf-connect.rb
+++ b/Casks/nordic-nrf-connect.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-connect' do
-  version '3.3.0'
-  sha256 '001f6901d89b7b136d1acf26acbc1e9eddf3b860c3941d9b856b13a50008ce6d'
+  version '3.3.1'
+  sha256 '02c354805e59b2794f9b6c0d2609b572531d1edb7ce2c9cc43b98825326bf560'
 
   # github.com/NordicSemiconductor/pc-nrfconnect-core/ was verified as official when first introduced to the cask
   url "https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases/download/v#{version}/nrfconnect-#{version}.dmg"

--- a/Casks/nordic-nrf-connect.rb
+++ b/Casks/nordic-nrf-connect.rb
@@ -6,7 +6,7 @@ cask 'nordic-nrf-connect' do
   url "https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases/download/v#{version}/nrfconnect-#{version}.dmg"
   appcast 'https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases.atom'
   name 'nRF Connect'
-  homepage 'https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF-Connect-for-desktop/'
+  homepage 'https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-desktop/'
 
   app 'nRF Connect.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.