### PR TITLE
acs-acr39u-smartcard-driver version upgrade

### DIFF
--- a/Casks/acs-acr39u-smartcard-driver.rb
+++ b/Casks/acs-acr39u-smartcard-driver.rb
@@ -1,8 +1,8 @@
 cask 'acs-acr39u-smartcard-driver' do
-  version '1.1.6.3'
-  sha256 'b3b8e9a3e4393953d2e1671b5baef6953d531599b5977b8a7d2b314d18b2af4a'
-
-  url "https://www.acs.com.hk/download-driver-unified/10954/ACS-Unified-INST-MacOSX-#{version.no_dots}-P.zip"
+  version '1.1.8'
+  sha256 'f1234d75178d892a133a410355a5a990cf75d2f33eba25d575943d4df632f3a4'
+  
+  url "https://www.acs.com.hk/download-driver-unified/11878/ACS-Unified-INST-MacOSX-#{version.no_dots}-P.zip"
   appcast 'https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/'
   name 'ACS Unified Installer'
   homepage 'https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/'

--- a/Casks/acs-acr39u-smartcard-driver.rb
+++ b/Casks/acs-acr39u-smartcard-driver.rb
@@ -1,7 +1,7 @@
 cask 'acs-acr39u-smartcard-driver' do
   version '1.1.8'
   sha256 '52653d4e06cf22c9d750632b237fa42abbf2ae7ea452102150d72b00e7d0329b'
-  
+
   url "https://www.acs.com.hk/download-driver-unified/11878/ACS-Unified-INST-MacOSX-#{version.no_dots}-P.zip"
   appcast 'https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/'
   name 'ACS Unified Installer'

--- a/Casks/acs-acr39u-smartcard-driver.rb
+++ b/Casks/acs-acr39u-smartcard-driver.rb
@@ -1,6 +1,6 @@
 cask 'acs-acr39u-smartcard-driver' do
   version '1.1.8'
-  sha256 'f1234d75178d892a133a410355a5a990cf75d2f33eba25d575943d4df632f3a4'
+  sha256 '52653d4e06cf22c9d750632b237fa42abbf2ae7ea452102150d72b00e7d0329b'
   
   url "https://www.acs.com.hk/download-driver-unified/11878/ACS-Unified-INST-MacOSX-#{version.no_dots}-P.zip"
   appcast 'https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/'


### PR DESCRIPTION
The driver version was updated to 1.1.8. Additionally the second subfolder of the driver url was changed from 10954 to 11878. I can't ascertain why that change was made or find a trend.

Closed pull request [1499](https://github.com/Homebrew/homebrew-cask-drivers/pull/1499) since this edit is slightly more involved than a normal automated update.
