### PR TITLE
Update qmk-toolbox from 0.0.16 to 0.0.17

### DIFF
--- a/Casks/qmk-toolbox.rb
+++ b/Casks/qmk-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'qmk-toolbox' do
-  version '0.0.16'
-  sha256 '9f59d7efa4cee10c995ee5c972473fc15fc9d622d7f7a7ee0a8bbf8352ad1d28'
+  version '0.0.17'
+  sha256 '645ff73223ddbb35b82b39f4a6c3fb40f20c2bdbda505ce4fb1a780507334f30'
 
   # github.com/qmk/qmk_toolbox was verified as official when first introduced to the cask
   url "https://github.com/qmk/qmk_toolbox/releases/download/#{version}/QMK.Toolbox.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.