### PR TITLE
Update loupedeck from 3.2 to 3.2.1

### DIFF
--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -1,9 +1,9 @@
 cask 'loupedeck' do
-  version '3.2'
-  sha256 '28b525df08e61f24e52900fd514043a8e0b6ae05dcac8e43a1e5a2d5c69f6bc0'
+  version '3.2.1'
+  sha256 '3a9d3486c0f8c3a8b8e26a04f4cb1de90228eb31eac882d98d90796a1289387a'
 
   # loupedeck-software-release.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://loupedeck-software-release.s3.amazonaws.com/Loupedeck+Software+version+#{version}/Loupedeck+#{version}.dmg"
+  url "https://loupedeck-software-release.s3.amazonaws.com/Loupedeck_Software_v#{version.dots_to_underscores}/Loupedeck_Software_v#{version.dots_to_underscores}.dmg"
   name 'Loupdeck'
   homepage 'https://loupedeck.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.