### PR TITLE
Update lmsclients-squeezeplay from 7.8.0r1188 to 7.8.0r1227

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -1,6 +1,6 @@
 cask 'lmsclients-squeezeplay' do
-  version '7.8.0r1188'
-  sha256 '767e7056336c8cd5e587212b98dbf78e5a75f8483ce2d54de1da36fc92aaebcf'
+  version '7.8.0r1227'
+  sha256 '2802555f092a616d1843e5812abb052d4d5ef8cb918657bf3867bd86ff5c654c'
 
   # downloads.sourceforge.net/lmsclients was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lmsclients/SqueezePlay-x86_64-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.