### PR TITLE
Update sonos from 11.0 to 11.1

### DIFF
--- a/Casks/sonos.rb
+++ b/Casks/sonos.rb
@@ -1,6 +1,6 @@
 cask 'sonos' do
-  version '11.0'
-  sha256 'a9c340872548f5e712b0685d4bc593b88db3abae57c32b85fb024ba8f1ce7143'
+  version '11.1'
+  sha256 'f93830f89073598eccf92c7c3d9e064330252e8e7152cdcb75094a4890ec13e8'
 
   url "https://update.sonos.com/software/mac/mdcr/SonosDesktopController#{version.no_dots}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.sonos.com/en/redir/controller_software_mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.