### PR TITLE
Update nordic-nrf-connect from 3.3.1 to 3.3.3

### DIFF
--- a/Casks/nordic-nrf-connect.rb
+++ b/Casks/nordic-nrf-connect.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-connect' do
-  version '3.3.1'
-  sha256 '02c354805e59b2794f9b6c0d2609b572531d1edb7ce2c9cc43b98825326bf560'
+  version '3.3.3'
+  sha256 '46f68fa1935b740fb44f9e057f1782313b93aa6baa576533537345b7b4437feb'
 
   # github.com/NordicSemiconductor/pc-nrfconnect-core/ was verified as official when first introduced to the cask
   url "https://github.com/NordicSemiconductor/pc-nrfconnect-core/releases/download/v#{version}/nrfconnect-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.