### PR TITLE
Update qnap-external-raid-manager from 1.2.4.1202 to 1.2.5.0413

### DIFF
--- a/Casks/qnap-external-raid-manager.rb
+++ b/Casks/qnap-external-raid-manager.rb
@@ -1,6 +1,6 @@
 cask 'qnap-external-raid-manager' do
-  version '1.2.4.1202'
-  sha256 'f44cb8d265e06ac30fd6b5bf42ccedbb3f6596736e092ffdf94e7ce79f19c6fa'
+  version '1.2.5.0413'
+  sha256 'd613c60ab38f6d86e622c4c5517bedbbbecaedda7c3ab75213644033faf7a0df'
 
   url "https://download.qnap.com/Storage/Utility/QNAPExternalRAIDManagerMac-#{version}.dmg"
   name 'QNAP External Raid Manager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.