### PR TITLE
Update elgato-stream-deck from 4.6.2.12889 to 4.6.4.12899

### DIFF
--- a/Casks/elgato-stream-deck.rb
+++ b/Casks/elgato-stream-deck.rb
@@ -1,6 +1,6 @@
 cask 'elgato-stream-deck' do
-  version '4.6.2.12889'
-  sha256 '6ed4c2a673973d5f6252de40aa6efdef4b8fb64e8849a76de22bf76ce5f23ae3'
+  version '4.6.4.12899'
+  sha256 'f53092262278cbd2622695d6eb9527e4ca0a214a6d4bce08bb3cf64ab4dffc13'
 
   url "https://edge.elgato.com/egc/macos/sd/Stream_Deck_#{version}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://gc-updates.elgato.com/mac/sd-update/final/download-website.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.