### PR TITLE
Update nordic-nrf-command-line-tools from 10.7.0 to 10.8.0

### DIFF
--- a/Casks/nordic-nrf-command-line-tools.rb
+++ b/Casks/nordic-nrf-command-line-tools.rb
@@ -1,6 +1,6 @@
 cask 'nordic-nrf-command-line-tools' do
-  version '10.7.0'
-  sha256 '3322c48a80b4694a1b62628c54a7b59507a8aac40e961fc6fd3d1fa856d12e22'
+  version '10.8.0'
+  sha256 '0c6af1ce68829d1ccc7b600219b255605a0c7ca704dabc92f74a191aa16af0e4'
 
   url "https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-#{version.major}-x-x/#{version.dots_to_hyphens}/nRF-Command-Line-Tools_#{version.dots_to_underscores}_OSX.tar"
   name 'nRF Command Line Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.