### PR TITLE
Update segger-ozone from 3.10h to 3.10i

### DIFF
--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -1,6 +1,6 @@
 cask 'segger-ozone' do
-  version '3.10h'
-  sha256 '9432a0180997966a03cb5b601b6a4d582043952e0ed5bf7ea97f1fe360ad2546'
+  version '3.10i'
+  sha256 'bac506843c4c35a88ac95a96a029bddc578db7f2577f66dc12fcb8984acf71e4'
 
   url "https://www.segger.com/downloads/jlink/Ozone_MacOSX_V#{version.no_dots}_Universal.pkg"
   appcast 'https://www.segger.com/downloads/jlink/ReleaseNotes_Ozone.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.