### PR TITLE
Update insta360-studio from 3.4.7,2020_20200403_211711 to 3.4.8,2020_20200430_175444

### DIFF
--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -1,8 +1,8 @@
 cask 'insta360-studio' do
-  version '3.4.7,2020_20200403_211711'
-  sha256 '281003b02ca67aacebac244089765105cbcbe690db2b0268c3f2510a8592931c'
+  version '3.4.8,2020_20200430_175444'
+  sha256 'b16ce5d49a350acff0ed29950518c19b38052a619a6baa341acbead640b1d640'
 
-  url "https://static.insta360.com/assets/storage/20200403/6541c24171997d44290716cac13e7dfb/Insta360_Studio_#{version.after_comma}_signed.pkg.zip"
+  url "https://static.insta360.com/assets/storage/20200508/2aac93342bc80e17434dc5568808c628/Insta360_Studio_#{version.after_comma}_signed.pkg.zip"
   name 'Insta360 Studio'
   homepage 'https://www.insta360.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.