### PR TITLE
Update blackvue-viewer from 1.37 to 3.00

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.37'
-  sha256 '4cc2aa62f0eed7bd8f292f6466f175c3941d5f0fcd7b04caf6dae9f1769d52fb'
+  version '3.00'
+  sha256 'd0a45307b6726c6ff5809d72d8b707ed838a86004d856ec6d36c4f1cb0a740a4'
 
   url 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=74331'
   appcast 'https://www.blackvue.com/download/blackvue-mac-viewer-cloud/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.