### PR TITLE
Upgrade displaylink from 5.2.1 to 5.2.4

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -12,8 +12,8 @@ cask 'displaylink' do
     version '5.2,1367'
     sha256 'dd9e5a900778c558c27994953052a7378d34e70d5163d6acf5f441d5785978f5'
   else
-    version '5.2.1,1478'
-    sha256 'd5f113a0f6779762333bbe52cacb97b6a6a3843e8351e079798d44742b2f2231'
+    version '5.2.4,1581'
+    sha256 '5e5680f8497b77b7a8a0e4920a17791b2b388dc11046ef58070967ed524204cd'
   end
 
   url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",


### PR DESCRIPTION
The following bugs have been fixed:

* Hub USB3.0 link power management control improvement to address connection stability
* WindowServer memory usage increases after DisplayLink dock replug
* All DisplayLink connected displays are in mirror mode

Full release notes can be found at http://assets.displaylink.com/live/downloads/release-notes/f1582_DisplayLink+USB+Graphics+Software+for+macOS+5.2.4-Release+Notes.txt.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
