### PR TITLE
Update loupedeck from 3.2.1 to 3.2.5

### DIFF
--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -1,9 +1,9 @@
 cask 'loupedeck' do
-  version '3.2.1'
-  sha256 '3a9d3486c0f8c3a8b8e26a04f4cb1de90228eb31eac882d98d90796a1289387a'
+  version '3.2.5'
+  sha256 '3c877d67521da04c7356e4a6a178932ecb3b9beb8b2b938e1f7cf0d32658c5b7'
 
   # loupedeck-software-release.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url "https://loupedeck-software-release.s3.amazonaws.com/Loupedeck_Software_v#{version.dots_to_underscores}/Loupedeck_Software_v#{version.dots_to_underscores}.dmg"
+  url "https://loupedeck-software-release.s3.amazonaws.com/Software+Release+#{version}/MacOS/Loupedeck_#{version.dots_to_underscores}.dmg"
   name 'Loupdeck'
   homepage 'https://loupedeck.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.