### PR TITLE
Update elektron-overbridge from 2.0.37.3 to 2.0.39.10,b70d78e8-b59a-50e5-b11b-86c4d30b2400

### DIFF
--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -8,7 +8,7 @@ cask 'elektron-overbridge' do
   name 'Overbridge'
   homepage 'https://www.elektron.se/overbridge/'
 
-  pkg "Elektron Overbridge Installer #{version}.pkg"
+  pkg "Elektron Overbridge Installer #{version.before_comma}.pkg"
 
   uninstall pkgutil:   'se.elektron.overbridge.*',
             launchctl: 'se.elektron.overbridge.engine',

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -1,9 +1,9 @@
 cask 'elektron-overbridge' do
-  version '2.0.37.3'
-  sha256 '3f54c2300af5d86b021e4400d78cad9ac5aea1c4b6ba96814a123521b87c3feb'
+  version '2.0.39.10,b70d78e8-b59a-50e5-b11b-86c4d30b2400'
+  sha256 'c939f84aab02026a3a3cbcc512da93c35e65d59985add6d365b9e830930ecf61'
 
   # se-elektron-devops.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url "https://se-elektron-devops.s3.amazonaws.com/release/8d1ef129-6161-52ac-b65a-ea18489fd654/Elektron_Overbridge_#{version}.dmg"
+  url "https://se-elektron-devops.s3.amazonaws.com/release/#{version.after_comma}/Elektron_Overbridge_#{version.before_comma}.dmg"
   appcast 'https://www.elektron.se/support/?connection=overbridge#resources'
   name 'Overbridge'
   homepage 'https://www.elektron.se/overbridge/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.