### PR TITLE
Update logitech-firmwareupdatetool from 1.2.109 to 2.0.47973

### DIFF
--- a/Casks/logitech-firmwareupdatetool.rb
+++ b/Casks/logitech-firmwareupdatetool.rb
@@ -1,11 +1,13 @@
 cask 'logitech-firmwareupdatetool' do
-  version '1.2.109'
-  sha256 '045d1ca198cc54ced6c43d34155325596ca22c0d08a4f49e786f4e775bdc1b08'
+  version '2.0.47973'
+  sha256 '4dae89363248fd000800f0d1b51167dfcf064dd1ce5bc42a2e0beeab6a0668f2'
 
   url 'https://download01.logi.com/web/ftp/pub/techsupport/keyboards/FirmwareUpdateToolInstaller.zip'
   appcast 'https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=07d54a46-c89d-11e9-9981-4556732441db'
   name 'Logitech Firmware Update Tool'
   homepage 'https://support.logi.com/hc/en-us/articles/360035037273'
+
+  container nested: 'FirmwareUpdateTool/FirmwareUpdateTool.zip'
 
   app 'FirmwareUpdateTool.app'
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).