### PR TITLE
Update yubico-yubikey-piv-manager from 1.4.2f to 1.4.2h

### DIFF
--- a/Casks/yubico-yubikey-piv-manager.rb
+++ b/Casks/yubico-yubikey-piv-manager.rb
@@ -10,7 +10,7 @@ cask 'yubico-yubikey-piv-manager' do
   pkg "yubikey-piv-manager-#{version}-mac.pkg"
 
   uninstall signal:  ['TERM', 'YubiKey PIV Manager'],
-            pkgutil: 'com.yubico.pkg.YubiKeyPIVManager'
+            pkgutil: ['com.yubico.pkg.YubiKeyPIVManager', 'YubiKey PIV Manager']
 
   zap trash: '~/Library/Saved Application State/YubiKey PIV Manager.savedState'
 end

--- a/Casks/yubico-yubikey-piv-manager.rb
+++ b/Casks/yubico-yubikey-piv-manager.rb
@@ -1,6 +1,6 @@
 cask 'yubico-yubikey-piv-manager' do
-  version '1.4.2f'
-  sha256 'b167425753dcac2c981e5e0da121c30c9a485600ab2c588c40eaec4456a4a846'
+  version '1.4.2h'
+  sha256 '579d1c92a9de556c829c05995a7f495c7f7d320fe7d9287d278688f8c04e8ce3'
 
   url "https://developers.yubico.com/yubikey-piv-manager/Releases/yubikey-piv-manager-#{version}-mac.pkg"
   appcast 'https://developers.yubico.com/yubikey-piv-manager/Release_Notes.html'

--- a/Casks/yubico-yubikey-piv-manager.rb
+++ b/Casks/yubico-yubikey-piv-manager.rb
@@ -10,7 +10,7 @@ cask 'yubico-yubikey-piv-manager' do
   pkg "yubikey-piv-manager-#{version}-mac.pkg"
 
   uninstall signal:  ['TERM', 'YubiKey PIV Manager'],
-            pkgutil: ['com.yubico.pkg.YubiKeyPIVManager', 'YubiKey PIV Manager']
+            pkgutil: 'YubiKey PIV Manager'
 
   zap trash: '~/Library/Saved Application State/YubiKey PIV Manager.savedState'
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).