### PR TITLE
Update kyocera-printer-drivers from 5.0a,2019.11.27 to 5.1,2020.07.01

### DIFF
--- a/Casks/kyocera-printer-drivers.rb
+++ b/Casks/kyocera-printer-drivers.rb
@@ -1,6 +1,6 @@
 cask 'kyocera-printer-drivers' do
-  version '5.0a,2019.11.27'
-  sha256 '022c1e9a710d157b4e68e4c0d5b519ca31280eb47c43296cdae6e92da864b41d'
+  version '5.1,2020.07.01'
+  sha256 '21bc52ac4a1d2d074a1c56bb17d76092dd0e2405648ffa960577e603eed7cd0c'
 
   # kyostatics.net/dlc/eu/driver/all/ was verified as official when first introduced to the cask
   url "https://cdn.kyostatics.net/dlc/eu/driver/all/kyocera_os_x_10_6.-downloadcenteritem-Single-File.downloadcenteritem.tmp/MacPhase#{version.before_comma.no_dots}_#{version.after_comma.dots_to_underscores}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).