### PR TITLE
Evoluent mouse drivers incompatible with Catalina

### DIFF
--- a/Casks/evoluent-vertical-mouse-device-controller.rb
+++ b/Casks/evoluent-vertical-mouse-device-controller.rb
@@ -7,6 +7,10 @@ cask "evoluent-vertical-mouse-device-controller" do
   name "Evoluent Vertical Mouse Device Controller"
   homepage "https://evoluent.com/"
 
+  # This cask is broken as of MacOS Catalina because it attempts to write
+  # to the root directory (/)
+  depends_on macos: "<= :mojave"
+
   pkg "Evoluent VerticalMouse Device Controller - #{version}.pkg"
 
   uninstall launchctl: "com.evoluent.agent",

--- a/Casks/evoluent-vertical-mouse-device-controller.rb
+++ b/Casks/evoluent-vertical-mouse-device-controller.rb
@@ -7,8 +7,6 @@ cask "evoluent-vertical-mouse-device-controller" do
   name "Evoluent Vertical Mouse Device Controller"
   homepage "https://evoluent.com/"
 
-  # This cask is broken as of MacOS Catalina because it attempts to write
-  # to the root directory (/)
   depends_on macos: "<= :mojave"
 
   pkg "Evoluent VerticalMouse Device Controller - #{version}.pkg"


### PR DESCRIPTION
Indicate the Evoluent Vertical Mouse Driver is incompatible with MacOS
versions newer than Mojave.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
