### PR TITLE
Update ubiquiti-unifi-controller from 5.14.22 to 5.14.23

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask "ubiquiti-unifi-controller" do
-  version "5.14.22"
-  sha256 "5dddf573c9034a12a5e3df38f36988ef03d5aac63224f1d2da4904d2b6b24b4d"
+  version "5.14.23"
+  sha256 "8bb520649bce8551b94b5a7cd0526b15ea5ffe8e279610af4c7b3f13c827ed7d"
 
   # dl.ubnt.com/ was verified as official when first introduced to the cask
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).