### PR TITLE
Update 8bitdo-firmware-updater from 1.1.3 to 1.1.6

### DIFF
--- a/Casks/8bitdo-firmware-updater.rb
+++ b/Casks/8bitdo-firmware-updater.rb
@@ -1,6 +1,6 @@
 cask "8bitdo-firmware-updater" do
-  version "1.1.3"
-  sha256 "9f3e00c3e28767dfdae0426833dbbe80cb4acae9644c54d72ef25c72610d4bba"
+  version "1.1.6"
+  sha256 "546d33a095f8d5b15798cb86c855fcc5dd37949be589c436c6c0547e7ad40b95"
 
   url "http://tools.8bitdo.com/8BitdoFirmwareUpdater/8BitDoFirmwareUpdaterV#{version}.zip"
   appcast "http://tools.8bitdo.com/8BitdoFirmwareUpdater/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).