### PR TITLE
Add ColorNavigator 7.app v7.11

### DIFF
--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -12,14 +12,14 @@ cask "eizo-colornavigator" do
   uninstall pkgutil: [
     "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
   ],
-  quit:    "com.eizo.ColorNavigator#{version.major}"
+            quit:    "com.eizo.ColorNavigator#{version.major}"
 
   zap delete: [
     "/Library/Application Support/EIZO/ColorNavigator 7",
     "~/Library/Application Support/EIZO/ColorNavigator 7",
   ],
-  rmdir: [
-    "/Library/Application Support/EIZO",
-    "~/Library/Application Support/EIZO",
-  ]
+      rmdir:  [
+        "/Library/Application Support/EIZO",
+        "~/Library/Application Support/EIZO",
+      ]
 end

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -12,14 +12,14 @@ cask "eizo-colornavigator" do
   uninstall pkgutil: [
     "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
   ],
-            quit:    "com.eizo.ColorNavigator#{version.major}"
+  quit:    "com.eizo.ColorNavigator#{version.major}"
 
   zap delete: [
     "/Library/Application Support/EIZO/ColorNavigator 7",
     "~/Library/Application Support/EIZO/ColorNavigator 7",
   ],
-      rmdir: [
-        "/Library/Application Support/EIZO",
-         "~/Library/Application Support/EIZO",
-           ]
+  rmdir: [
+    "/Library/Application Support/EIZO",
+    "~/Library/Application Support/EIZO",
+  ]
 end

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -9,9 +9,7 @@ cask "eizo-colornavigator" do
 
   pkg "ColorNavigator#{version.no_dots}.pkg"
 
-  uninstall pkgutil: [
-    "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
-  ],
+  uninstall pkgutil: "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
             quit:    "com.eizo.ColorNavigator#{version.major}",
             delete:  "/Library/Application Support/EIZO/ColorNavigator #{version.major}",
             rmdir:   "/Library/Application Support/EIZO"

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -15,8 +15,8 @@ cask "eizo-colornavigator" do
             quit:    "com.eizo.ColorNavigator#{version.major}"
 
   zap delete: [
-    "/Library/Application Support/EIZO/ColorNavigator 7",
-    "~/Library/Application Support/EIZO/ColorNavigator 7",
+    "/Library/Application Support/EIZO/ColorNavigator #{version.major}",
+    "~/Library/Application Support/EIZO/ColorNavigator #{version.major}",
   ],
       rmdir:  [
         "/Library/Application Support/EIZO",

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -2,9 +2,9 @@ cask "eizo-colornavigator" do
   version "7.11"
   sha256 "4d0c5064bfcfe9f1387bb44792a0835a627a9f4cf49dd20daf9f64662a733af8"
 
-  url "https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator#{version.major.no_dots}/ColorNavigator#{version.no_dots}.pkg"
-  name "ColorNavigator 7"
-  desc "Used for calibrating Eizo Coloredge screens"
+  url "https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator#{version.major}/ColorNavigator#{version.no_dots}.pkg"
+  name "Eizo ColorNavigator"
+  desc "Calibrate Eizo Coloredge screens"
   homepage "https://www.eizoglobal.com/products/coloredge/cn7/"
 
   pkg "ColorNavigator#{version.no_dots}.pkg"
@@ -12,8 +12,9 @@ cask "eizo-colornavigator" do
   uninstall pkgutil: [
     "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
   ],
+            quit:    "com.eizo.ColorNavigator#{version.major}",
             delete:  [
-              "/Library/Application\ Support/EIZO/",
-              "~/Library/Application\ Support/EIZO/",
+              "/Library/Application Support/EIZO/",
+              "~/Library/Application Support/EIZO/",
             ]
 end

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -1,0 +1,19 @@
+cask "eizo-colornavigator" do
+  version "7.11"
+  sha256 "4d0c5064bfcfe9f1387bb44792a0835a627a9f4cf49dd20daf9f64662a733af8"
+
+  url "https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator#{version.major.no_dots}/ColorNavigator#{version.no_dots}.pkg"
+  name "ColorNavigator 7"
+  desc "Used for calibrating Eizo Coloredge screens"
+  homepage "https://www.eizoglobal.com/products/coloredge/cn7/"
+
+  pkg "ColorNavigator#{version.no_dots}.pkg"
+
+  uninstall pkgutil: [
+    "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
+  ],
+            delete:  [
+              "/Library/Application\ Support/EIZO/",
+              "~/Library/Application\ Support/EIZO/",
+            ]
+end

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -12,14 +12,10 @@ cask "eizo-colornavigator" do
   uninstall pkgutil: [
     "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
   ],
-            quit:    "com.eizo.ColorNavigator#{version.major}"
+            quit:    "com.eizo.ColorNavigator#{version.major}",
+            delete:  "/Library/Application Support/EIZO/ColorNavigator #{version.major}",
+            rmdir:   "/Library/Application Support/EIZO"
 
-  zap delete: [
-    "/Library/Application Support/EIZO/ColorNavigator #{version.major}",
-    "~/Library/Application Support/EIZO/ColorNavigator #{version.major}",
-  ],
-      rmdir:  [
-        "/Library/Application Support/EIZO",
-        "~/Library/Application Support/EIZO",
-      ]
+  zap trash: "~/Library/Application Support/EIZO/ColorNavigator #{version.major}",
+      rmdir: "~/Library/Application Support/EIZO"
 end

--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -12,9 +12,14 @@ cask "eizo-colornavigator" do
   uninstall pkgutil: [
     "com.eizo.pkg.ColorNavigator#{version.major.no_dots}",
   ],
-            quit:    "com.eizo.ColorNavigator#{version.major}",
-            delete:  [
-              "/Library/Application Support/EIZO/",
-              "~/Library/Application Support/EIZO/",
-            ]
+            quit:    "com.eizo.ColorNavigator#{version.major}"
+
+  zap delete: [
+    "/Library/Application Support/EIZO/ColorNavigator 7",
+    "~/Library/Application Support/EIZO/ColorNavigator 7",
+  ],
+      rmdir: [
+        "/Library/Application Support/EIZO",
+         "~/Library/Application Support/EIZO",
+           ]
 end


### PR DESCRIPTION
The Eizo ColorNavigator tool is needed for hardware calibration of their Coloredge screens used by many profesional photographers.

The token reference told me to call the cask "colornavigator". I looked at this repo, and noticed that the company name is in front of the program name most of the time, so I did the same.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
