### PR TITLE
asix-ax88179: various updates

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -2,14 +2,14 @@ cask "asix-ax88179" do
   version "2.18.0,1.8.0"
   sha256 "a646f75aed3d45435409505b9c3ae90364862d4572ca74e26c282bb1510c7105"
 
-  url "https://www.asix.com.tw/FrootAttach/driver/AX88179_178A_macOS_10.9_to_10.15_Driver_Installer_v#{version.before_comma}.zip"
+  url "https://www.asix.com.tw/en/support/download/file/119"
   name "AX88179"
   desc "USB 3.0 to gigabit ethernet drivers for ASIX Electronics devices"
-  homepage "https://www.asix.com.tw/download.php?sub=driverdetail&PItemID=131"
+  homepage "https://www.asix.com.tw/en/support/download"
 
   container nested: "AX88179_178A_macOS_10.9_to_10.15_Driver_Installer_v#{version.before_comma}/AX88179_178A_v#{version.before_comma}.dmg"
 
-  app "AX88179_178A_v#{version.before_comma}.app"
+  installer manual: "AX88179_178A_v#{version.before_comma}.app"
 
   uninstall_preflight do
     system_command "/usr/sbin/installer",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I have tested this and running the `app` manually installs the `kext` (among other things) to `/Library/StagedExtensions/Library/Extensions/AX88179_178A.kext` and `/Library/Extensions/AX88179_178A.kext`, which are **NOT** loaded by default, but are loaded on-demand when the appropriate USB dongle is inserted.

I believe this is by design, and hence `kextload` should not be invoked here.

The `uninstall_preflight` works as intended and removes these two `kext` files and `com.asix.pkg.ax88179-178a-10.15`, so that invoking `uninstall kext` and `uninstall pkgutil` are not required.

The final ` uninstall pkgutil` then cleans up the `pkg` from the `uninstall_preflight`.

No further `zap` stanza is required from what I can see.