### PR TITLE
sony-ps4-remote-play: Zap new directory

### DIFF
--- a/Casks/sony-ps4-remote-play.rb
+++ b/Casks/sony-ps4-remote-play.rb
@@ -14,6 +14,7 @@ cask "sony-ps4-remote-play" do
 
   zap trash: [
     "~/Library/Application Support/Sony Corporation/PS4 Remote Play",
+    "~/Library/Application Support/Sony Corporation/PS Remote Play",
     "~/Library/Caches/com.playstation.RemotePlay",
     "~/Library/Cookies/com.playstation.RemotePlay.binarycookies",
     "~/Library/Preferences/com.playstation.RemotePlay.plist",

--- a/Casks/sony-ps4-remote-play.rb
+++ b/Casks/sony-ps4-remote-play.rb
@@ -4,6 +4,7 @@ cask "sony-ps4-remote-play" do
 
   url "https://remoteplay.dl.playstation.net/remoteplay/module/mac/RemotePlayInstaller.pkg"
   name "PS4 Remote Play"
+  desc "Application to control your PlayStation 4"
   homepage "https://remoteplay.dl.playstation.net/remoteplay/"
 
   depends_on macos: ">= :yosemite"


### PR DESCRIPTION
Newer version of the software is now named as "PS Remote Play".

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
