### PR TITLE
Update elecom-mouse-assistant from 5.2.1.000 to 5.2.1.001

### DIFF
--- a/Casks/elecom-mouse-assistant.rb
+++ b/Casks/elecom-mouse-assistant.rb
@@ -1,6 +1,6 @@
 cask "elecom-mouse-assistant" do
-  version "5.2.1.000"
-  sha256 "ccaa064398abdcaf23ed9a6d34b862253bd9f9d60075180bd8afdd9cd98d81bc"
+  version "5.2.1.001"
+  sha256 "72df768accf90b8e732ca9ef4ff8b13970db90f01aa9fba7535e08ad6ee15751"
 
   url "https://dl.elecom.co.jp/support/download/peripheral/mouse/assistant/mac/ELECOM_Mouse_Installer_#{version}.zip"
   appcast "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).