### PR TITLE
Update eizo-colornavigator from 7.11 to 7.12

### DIFF
--- a/Casks/eizo-colornavigator.rb
+++ b/Casks/eizo-colornavigator.rb
@@ -1,6 +1,6 @@
 cask "eizo-colornavigator" do
-  version "7.11"
-  sha256 "4d0c5064bfcfe9f1387bb44792a0835a627a9f4cf49dd20daf9f64662a733af8"
+  version "7.12"
+  sha256 "8d49fe582889b44c4f7194935e96517341ac1180a07c8f3c6a33a3f7978cac38"
 
   url "https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator#{version.major}/ColorNavigator#{version.no_dots}.pkg"
   name "Eizo ColorNavigator"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
