### PR TITLE
Update asix-ax88179 version to beta 2

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -1,5 +1,5 @@
 cask "asix-ax88179" do
-  version "2.19.0_beta2,1.8.0"
+  version "2.19.0,1.8.0"
   sha256 "23dca0c54f2779c135dc250a937314ad0b26252c2dbfdd2eaa36bf284ba09a72"
 
   url "https://www.asix.com.tw/en/support/download/file/119"
@@ -7,7 +7,7 @@ cask "asix-ax88179" do
   desc "USB 3.0 to gigabit ethernet drivers for ASIX Electronics devices"
   homepage "https://www.asix.com.tw/en/support/download"
 
-  container nested: "AX88179_178A_macOS_10.9_to_10.15_Driver_Installer_v#{version.before_comma}/AX88179_178A_v#{version.before_comma}.dmg"
+  container nested: "AX88179_178A_macOS_10.9_to_11_Driver_Installer_v#{version.before_comma}_beta2/AX88179_178A_v#{version.before_comma}.dmg"
 
   installer manual: "AX88179_178A_v#{version.before_comma}.app"
 

--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -1,6 +1,6 @@
 cask "asix-ax88179" do
-  version "2.18.0,1.8.0"
-  sha256 "a646f75aed3d45435409505b9c3ae90364862d4572ca74e26c282bb1510c7105"
+  version "2.19.0_beta2,1.8.0"
+  sha256 "23dca0c54f2779c135dc250a937314ad0b26252c2dbfdd2eaa36bf284ba09a72"
 
   url "https://www.asix.com.tw/en/support/download/file/119"
   name "AX88179"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

MacOS Big sur has been released and there's no stable release yet for this Ethernet driver from Asix.