### PR TITLE
Update insta360-studio from 3.5.4,2020_20201029_064913:20201029.749ae151b284b24ee59feeced39256b6 to 3.5.5,2020_20201111_173104:20201111.037377491bc0bc838b327e5f7287bdec

### DIFF
--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -1,6 +1,6 @@
 cask "insta360-studio" do
-  version "3.5.4,2020_20201029_064913:20201029.749ae151b284b24ee59feeced39256b6"
-  sha256 "b17676b7de5ba30630f0467c13c2bb32e9d74542a5531f8a69302d979e240e24"
+  version "3.5.5,2020_20201111_173104:20201111.037377491bc0bc838b327e5f7287bdec"
+  sha256 "383f83dd82af47263827b3327e0bc31b956af1ddfd5e443e160ec05a30438584"
 
   url "https://res.insta360.com/static/assets/storage/#{version.after_colon.major}/#{version.after_colon.minor}/Insta360_Studio_#{version.after_comma.before_colon}_signed.pkg"
   name "Insta360 Studio"

--- a/Casks/sonos.rb
+++ b/Casks/sonos.rb
@@ -2,7 +2,7 @@ cask "sonos" do
   version "12.2"
   sha256 "342864b703d8f2d6c3e0601394273ab87cf9e9dcec1a77e6e78ce2e13339e182"
 
-  url "https://update.sonos.com/software/mac/mdcr/SonosDesktopController#{version.no_dots}.dmg"
+  url "https://update-software.sonos.com/software/mac/mdcr/SonosDesktopController#{version.no_dots}.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.sonos.com/en/redir/controller_software_mac2",
           must_contain: version.no_dots
   name "Sonos"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).