### PR TITLE
Update datacolor-spyder-elite from 5.3 to 5.7

### DIFF
--- a/Casks/datacolor-spyder-elite.rb
+++ b/Casks/datacolor-spyder-elite.rb
@@ -2,29 +2,30 @@ cask "datacolor-spyder-elite" do
   version "5.7"
   sha256 "4474f20807ab97c3337a4d03526b7a348c387509fb8ff6cec97276269ecfc495"
 
-  # d3d9ci7ypuovlo.cloudfront.net/spyder was verified as official when first introduced to the cask
-  url "https://d3d9ci7ypuovlo.cloudfront.net/spyder#{version.major}/Spyder5Elite_#{version}.pkg.zip"
+  # d3d9ci7ypuovlo.cloudfront.net/ was verified as official when first introduced to the cask
+  url "https://d3d9ci7ypuovlo.cloudfront.net/spyder#{version.major}/Spyder#{version.major}Elite_#{version}.pkg.zip"
   name "Spyder Elite"
+  desc "Monitor calibration tool"
   homepage "https://www.datacolor.com/photography-design/product-overview/spyder#{version.major}-family/#spyder#{version.major}elite"
 
   auto_updates true
 
-  pkg "Spyder5Elite #{version}.pkg"
+  pkg "Spyder#{version.major}Elite #{version}.pkg"
 
   uninstall signal:  [
     ["TERM", "com.datacolor.spyder#{version.major}elite"],
     ["TERM", "com.datacolor.spyder#{version.major}utility"],
   ],
             delete:  "/Applications/Datacolor/Spyder#{version.major}Elite",
-            pkgutil: "com.datacolor.pkg.spyder5elite",
+            pkgutil: "com.datacolor.pkg.spyder#{version.major}elite",
             rmdir:   "/Applications/Datacolor"
 
   zap trash: [
-    "~/Library/Application Support/MindVision/Spyder5Elite_Installer.xtm",
-    "~/Library/Caches/com.datacolor.spyder5elite",
-    "~/Library/Preferences/Datacolor/Spyder5Elite",
+    "~/Library/Application Support/MindVision/Spyder#{version.major}Elite_Installer.xtm",
+    "~/Library/Caches/com.datacolor.spyder#{version.major}elite",
+    "~/Library/Preferences/Datacolor/Spyder#{version.major}Elite",
     "~/Library/Preferences/Datacolor/SpyderUtility",
-    "~/Library/Saved Application State/com.datacolor.spyder5elite.savedState",
+    "~/Library/Saved Application State/com.datacolor.spyder#{version.major}elite.savedState",
   ],
       rmdir: "~/Library/Preferences/Datacolor"
 end

--- a/Casks/datacolor-spyder-elite.rb
+++ b/Casks/datacolor-spyder-elite.rb
@@ -1,15 +1,15 @@
 cask "datacolor-spyder-elite" do
-  version "5.3"
-  sha256 "aac0c688f34380737af11da28b9c48164b15800606353cf80090ecd54d2d0ba3"
+  version "5.7"
+  sha256 "4474f20807ab97c3337a4d03526b7a348c387509fb8ff6cec97276269ecfc495"
 
   # d3d9ci7ypuovlo.cloudfront.net/spyder was verified as official when first introduced to the cask
-  url "https://d3d9ci7ypuovlo.cloudfront.net/spyder#{version.major}/Spyder#{version.major}Elite_#{version}_OSX_Installer.zip"
+  url "https://d3d9ci7ypuovlo.cloudfront.net/spyder#{version.major}/Spyder5Elite_#{version}.pkg.zip"
   name "Spyder Elite"
   homepage "https://www.datacolor.com/photography-design/product-overview/spyder#{version.major}-family/#spyder#{version.major}elite"
 
   auto_updates true
 
-  installer manual: "Spyder#{version.major}Elite_#{version}_OSX_Installer.app"
+  pkg "Spyder5Elite #{version}.pkg"
 
   uninstall signal: [
     ["TERM", "com.datacolor.spyder#{version.major}elite"],

--- a/Casks/datacolor-spyder-elite.rb
+++ b/Casks/datacolor-spyder-elite.rb
@@ -11,12 +11,13 @@ cask "datacolor-spyder-elite" do
 
   pkg "Spyder5Elite #{version}.pkg"
 
-  uninstall signal: [
+  uninstall signal:  [
     ["TERM", "com.datacolor.spyder#{version.major}elite"],
     ["TERM", "com.datacolor.spyder#{version.major}utility"],
   ],
-            delete: "/Applications/Datacolor/Spyder#{version.major}Elite",
-            rmdir:  "/Applications/Datacolor"
+            delete:  "/Applications/Datacolor/Spyder#{version.major}Elite",
+            pkgutil: "com.datacolor.pkg.spyder5elite",
+            rmdir:   "/Applications/Datacolor"
 
   zap trash: [
     "~/Library/Application Support/MindVision/Spyder5Elite_Installer.xtm",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).