### PR TITLE
Update brother-p-touch-update-software from 1.5.5,15:dlfp100785 to 1.5.6,110:dlfp100885

### DIFF
--- a/Casks/brother-p-touch-update-software.rb
+++ b/Casks/brother-p-touch-update-software.rb
@@ -1,6 +1,6 @@
 cask "brother-p-touch-update-software" do
-  version "1.5.5,15:dlfp100785"
-  sha256 "c6e1afdb1daf04c143532f9dab019a764a2f6e07567c1b42d61d34232b990c32"
+  version "1.5.6,110:dlfp100885"
+  sha256 "179cd72961d1f2b8fba1146a4b636ca1529e8fc8adecac0165111ac36bd85a7a"
 
   url "https://download.brother.com/welcome/#{version.after_colon}/pum#{version.before_comma.no_dots}x#{version.after_comma.before_colon}all.dmg"
   name "Brother P-touch Update Software"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).