### PR TITLE
Bump drobo-dashboard to 3.5.2

### DIFF
--- a/Casks/drobo-dashboard.rb
+++ b/Casks/drobo-dashboard.rb
@@ -1,10 +1,11 @@
 cask "drobo-dashboard" do
-  version "3.5.1,115249"
-  sha256 "86b87e27bb1926b3b456986ee11d8ee0d8b39a6f82fd8c01dd4e5224fbfd6998"
+  version "3.5.2,115659"
+  sha256 "6094b749c2389d9edd49f423b7f77ae9e36e6d35c1db28b7f3424814ac96afce"
 
   url "https://files.drobo.com/webrelease/dashboard/Drobo-Dashboard-#{version.before_comma}.dmg"
   appcast "https://www.drobo.com/docs/start-drobo/"
   name "Drobo Dashboard"
+  desc "Management software and drivers for Data Robotics storage devices"
   homepage "https://www.drobo.com/"
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
Upstream release notes are not available, but 3.5.2 restores DriverKit Thunderbolt compatibility under Big Sur.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-drivers/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
