### PR TITLE
Update lmsclients-squeezeplay from 7.8.0r1286 to 7.8.0r1291

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -1,6 +1,6 @@
 cask "lmsclients-squeezeplay" do
-  version "7.8.0r1286"
-  sha256 "f0dd0590013d4472fcbd1fc745581616120957cd0f9136c6483b0b7347f61d66"
+  version "7.8.0r1291"
+  sha256 "f712eb1fbdcb150a6f0e20827b15589411e9543dd3f7c5f6556314664784b4b7"
 
   # downloads.sourceforge.net/lmsclients/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lmsclients/SqueezePlay-x86_64-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).