### PR TITLE
Update qnap-external-raid-manager from 1.2.5.0514 to 1.3.0.1127

### DIFF
--- a/Casks/qnap-external-raid-manager.rb
+++ b/Casks/qnap-external-raid-manager.rb
@@ -1,6 +1,6 @@
 cask "qnap-external-raid-manager" do
-  version "1.2.5.0514"
-  sha256 "e39acc998a1cc1be1cd3b4ecc53a6a85f09543c7f2c9f983a62fb03874299f1c"
+  version "1.3.0.1127"
+  sha256 "b0d542eda74f8c8ae31bdc8db8205e015b7947c5262458114ebee1dbef24c711"
 
   url "https://download.qnap.com/Storage/Utility/QNAPExternalRAIDManagerMac-#{version}.dmg"
   name "QNAP External Raid Manager"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).