### PR TITLE
Update roland-quad-capture-usb-driver from 1.5.5,15 to 1.5.6,11

### DIFF
--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -3,14 +3,20 @@ cask "roland-quad-capture-usb-driver" do
     version "1.5.2,10:24c21855-3c40-469c-a40c-7647a52bf022"
     sha256 "da575f4b3874e0042fddffb4462f4521019ceaa3f44942f64bce099b426cf2d1"
     url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
+
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
   elsif MacOS.version <= :sierra
     version "1.5.3,12:199aee04-dd6b-4a9c-9945-ba9ffb295113"
     sha256 "712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770"
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
+
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
   elsif MacOS.version <= :mojave
     version "1.5.4,13:53d8a307-a8ae-4f9b-9a59-a1adb8c67012"
     sha256 "d3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117"
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
+
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
   else
     version "1.5.6,11"
     sha256 "0d77926e818e1da93ea2f980ef29d840015f085ec134a68a2501b1ccfd5ddfde"
@@ -23,7 +29,7 @@ cask "roland-quad-capture-usb-driver" do
 
   depends_on macos: ">= :yosemite"
 
-  pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
+  pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver#{version.after_comma}.pkg"
 
   uninstall pkgutil:   "jp.co.roland.QuadCapture.*",
             launchctl: [

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -12,9 +12,9 @@ cask "roland-quad-capture-usb-driver" do
     sha256 "d3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117"
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
   else
-    version "1.5.5,15"
-    sha256 "fce600fdbd50b50d69a676700ef42ee038db50d201874dadf3c0e1ac291df23f"
-    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+    version "1.5.6,11"
+    sha256 "0d77926e818e1da93ea2f980ef29d840015f085ec134a68a2501b1ccfd5ddfde"
+    url "https://static.roland.com/assets/media/tgz/quad_mac#{version.after_comma}drv#{version.before_comma.no_dots}.tgz"
   end
 
   appcast "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers"

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -1,26 +1,34 @@
 cask "roland-quad-capture-usb-driver" do
   if MacOS.version <= :yosemite
-    version "1.5.2,10:24c21855-3c40-469c-a40c-7647a52bf022"
+    version "1.5.2,10"
     sha256 "da575f4b3874e0042fddffb4462f4521019ceaa3f44942f64bce099b426cf2d1"
-    url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
+    url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
-    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
   elsif MacOS.version <= :sierra
-    version "1.5.3,12:199aee04-dd6b-4a9c-9945-ba9ffb295113"
+    version "1.5.3,12"
     sha256 "712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770"
-    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
-    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
   elsif MacOS.version <= :mojave
-    version "1.5.4,13:53d8a307-a8ae-4f9b-9a59-a1adb8c67012"
+    version "1.5.4,13"
     sha256 "d3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117"
-    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma.before_colon}d#{version.before_comma.no_dots}.tgz"
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
-    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma.before_colon}.pkg"
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
+  elsif MacOS.version <= :catalina
+    version "1.5.5,15"
+    sha256 "fce600fdbd50b50d69a676700ef42ee038db50d201874dadf3c0e1ac291df23f"
+    url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
+
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
   else
     version "1.5.6,11"
     sha256 "0d77926e818e1da93ea2f980ef29d840015f085ec134a68a2501b1ccfd5ddfde"
     url "https://static.roland.com/assets/media/tgz/quad_mac#{version.after_comma}drv#{version.before_comma.no_dots}.tgz"
+
+    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver#{version.after_comma}.pkg"
   end
 
   appcast "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers"
@@ -28,8 +36,6 @@ cask "roland-quad-capture-usb-driver" do
   homepage "https://www.roland.com/us/products/quad-capture/"
 
   depends_on macos: ">= :yosemite"
-
-  pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver#{version.after_comma}.pkg"
 
   uninstall pkgutil:   "jp.co.roland.QuadCapture.*",
             launchctl: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).