### PR TITLE
Update bose-soundtouch from 26.0.0-3251-ff6a93d,st2_2020_b103e58e to 26.0.0-3251-ff6a93d,3_2020_a3b99494

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -21,10 +21,8 @@ cask "bose-soundtouch" do
     args:       ["--mode", "unattended"],
     sudo:       true,
   },
-            quit:   [
-              "com.Bose.SoundTouch",
-              "io.qt.SoundTouchHelper",
-            ]
+            signal: ["TERM", "com.Bose.SoundTouch"],
+            quit:   "io.qt.SoundTouchHelper",
 
   zap trash: [
     "~/Library/Application Support/SoundTouch",

--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,9 +1,9 @@
 cask "bose-soundtouch" do
-  version "26.0.0-3251-ff6a93d,3_2020_a3b99494"
+  version "26.0.0-3251-ff6a93d,st3_2020_a3b99494"
   sha256 "be74aeaa1e73bd6b07d92ceb5fcff5b58c4023eb7ccdb034fea842080554aa4e"
 
-  url "https://downloads.bose.com/ced/soundtouch/st#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
-  appcast "https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html"
+  url "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
+  appcast "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/index.xml"
   name "Bose Soundtouch Controller App"
   desc "Control Bose SoundTouch systems from your computer"
   homepage "https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html"

--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -16,13 +16,14 @@ cask "bose-soundtouch" do
     sudo:       true,
   }
 
-  uninstall script: {
+  uninstall script:    {
     executable: "/Applications/SoundTouch/uninstall.app/Contents/MacOS/installbuilder.sh",
     args:       ["--mode", "unattended"],
     sudo:       true,
   },
-            signal: ["TERM", "com.Bose.SoundTouch"],
-            quit:   "io.qt.SoundTouchHelper"
+            signal:    ["TERM", "com.Bose.SoundTouch"],
+            quit:      "io.qt.SoundTouchHelper",
+            launchctl: "com.Bose.SoundTouch"
 
   zap trash: [
     "~/Library/Application Support/SoundTouch",

--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -22,7 +22,7 @@ cask "bose-soundtouch" do
     sudo:       true,
   },
             signal: ["TERM", "com.Bose.SoundTouch"],
-            quit:   "io.qt.SoundTouchHelper",
+            quit:   "io.qt.SoundTouchHelper"
 
   zap trash: [
     "~/Library/Application Support/SoundTouch",

--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,9 +1,9 @@
 cask "bose-soundtouch" do
-  version "26.0.0-3251-ff6a93d,st2_2020_b103e58e"
+  version "26.0.0-3251-ff6a93d,3_2020_a3b99494"
   sha256 "be74aeaa1e73bd6b07d92ceb5fcff5b58c4023eb7ccdb034fea842080554aa4e"
 
-  url "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
-  appcast "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/index.xml"
+  url "https://downloads.bose.com/ced/soundtouch/st#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
+  appcast "https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html"
   name "Bose Soundtouch Controller App"
   desc "Control Bose SoundTouch systems from your computer"
   homepage "https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.