### PR TITLE
Remove manual move after download

### DIFF
--- a/Casks/elgato-thunderbolt-dock.rb
+++ b/Casks/elgato-thunderbolt-dock.rb
@@ -5,16 +5,11 @@ cask "elgato-thunderbolt-dock" do
   url "https://update.elgato.com/mac/thunderbolt-dock-update/download.php"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://update.elgato.com/mac/thunderbolt-dock-update/download.php"
   name "Elgato Thunderbolt Dock"
+  desc "Menu bar utility for Elgato Thunderbolt docks"
   homepage "https://www.elgato.com/en/dock/thunderbolt-3"
 
   depends_on macos: ">= :el_capitan"
   container type: :pkg
-
-  pkg "Elgato_Thunderbolt_Dock_Software_#{version.before_comma}_#{version.after_comma}.pkg"
-
-  preflight do
-    system_command "/bin/mv", args: ["--", staged_path.join("download.php"), staged_path.join("Elgato_Thunderbolt_Dock_Software_#{version.before_comma}_#{version.after_comma}.pkg")]
-  end
 
   uninstall pkgutil:    [
     "com.elgato.Elgato-Thunderbolt-Dock-Utility",

--- a/Casks/elgato-thunderbolt-dock.rb
+++ b/Casks/elgato-thunderbolt-dock.rb
@@ -1,15 +1,16 @@
 cask "elgato-thunderbolt-dock" do
-  version "1.2.10,131"
-  sha256 :no_check
+  version "1.2.10.131_40"
+  sha256 "e76aff1d404451fa87d42c566475e83a09a15318cf33ad9219ed3792d5a7a098"
 
-  url "https://update.elgato.com/mac/thunderbolt-dock-update/download.php"
+  url "https://edge.elgato.com/thunderbolt-dock/Elgato_Thunderbolt_Dock_Software_#{version}.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://update.elgato.com/mac/thunderbolt-dock-update/download.php"
   name "Elgato Thunderbolt Dock"
   desc "Menu bar utility for Elgato Thunderbolt docks"
   homepage "https://www.elgato.com/en/dock/thunderbolt-3"
 
   depends_on macos: ">= :el_capitan"
-  container type: :pkg
+
+  pkg "Elgato_Thunderbolt_Dock_Software_#{version}.pkg"
 
   uninstall pkgutil:    [
     "com.elgato.Elgato-Thunderbolt-Dock-Utility",


### PR DESCRIPTION
It seems that the download now gets the correct name, not `download.php`, and the `preflight` stanza used to rename it is no longer necessary. Also added `desc` stanza to pass audit.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.