### PR TITLE
shureplus-motiv: add formula for Shure microphones

### DIFF
--- a/Casks/shureplus-motiv.rb
+++ b/Casks/shureplus-motiv.rb
@@ -1,0 +1,20 @@
+cask "shureplus-motiv" do
+  version "1.0.9.26"
+  sha256 "39ed1e4208c9784b84f449eaebb35996a47f9df5c570ce00fcbb23de5f9c10a7"
+
+  url "https://d24z4d3zypmncx.cloudfront.net/Software/shureplus-motiv/ShurePlusMOTIV_Mac_#{version}.dmg",
+      verified: "https://d24z4d3zypmncx.cloudfront.net/Software/shureplus-motiv/"
+  name "ShurePlus MOTIV"
+  desc "Additional features and controls for Shure MV7 and MV88+ microphones"
+  homepage "https://www.shure.com/en-US/products/software/shure_plus_motiv_desktop"
+
+  app "ShurePlus MOTIV.app"
+
+  zap trash: [
+    "~/Library/Application Support/shure.motiv",
+    "~/Library/Saved Application State/com.shure.motiv.desktop.savedState",
+    "~/Library/Preferences/com.shure.motiv.desktop.plist",
+    "~/Library/Logs/ShurePlus MOTIV",
+    "~/Library/Logs/shure.motiv",
+  ]
+end

--- a/Casks/shureplus-motiv.rb
+++ b/Casks/shureplus-motiv.rb
@@ -12,9 +12,9 @@ cask "shureplus-motiv" do
 
   zap trash: [
     "~/Library/Application Support/shure.motiv",
-    "~/Library/Saved Application State/com.shure.motiv.desktop.savedState",
-    "~/Library/Preferences/com.shure.motiv.desktop.plist",
     "~/Library/Logs/ShurePlus MOTIV",
     "~/Library/Logs/shure.motiv",
+    "~/Library/Preferences/com.shure.motiv.desktop.plist",
+    "~/Library/Saved Application State/com.shure.motiv.desktop.savedState",
   ]
 end


### PR DESCRIPTION
This adds a cask for MOTIV software from Shure for use with Shure MV7 and MV88+ microphones


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.