### PR TITLE
update logitech-g-hub from latest to 2020.12.9532

### DIFF
--- a/Casks/logitech-g-hub.rb
+++ b/Casks/logitech-g-hub.rb
@@ -1,5 +1,5 @@
 cask "logitech-g-hub" do
-  version :latest
+  version "2020.12.9532"
   sha256 :no_check
 
   url "https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.zip",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.