### PR TITLE
Update segger-jlink from 6.88b to 6.94a

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,19 +1,35 @@
 cask "segger-jlink" do
-  version "6.88b"
-  sha256 "54e8d896e1fec6de911d97aea82b6524f132abc24695918712b8f5673a3f26bf"
+  version "6.94a"
 
-  url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}.pkg",
-      using: :post,
-      data:  {
-        "accept_license_agreement" => "accepted",
-        "non_emb_ctr"              => "confirmed",
-        "submit"                   => "Download software",
-      }
+  if Hardware::CPU.intel?
+    sha256 "7a3ad75e8594293573eda14704161e871ee25d22261ce8baf4fbb4fbca2cf4ec"
+
+    url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}_x86_64.pkg",
+        using: :post,
+        data:  {
+          "accept_license_agreement" => "accepted",
+          "non_emb_ctr"              => "confirmed",
+          "submit"                   => "Download software",
+        }
+
+    pkg "JLink_MacOSX_V#{version.no_dots}_x86_64.pkg"
+  else
+    sha256 "7455ef0fd5512aa25ae178cb590e6ee055504fdd327775ffb2d1591fbed7fc10"
+
+    url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}_arm64.pkg",
+        using: :post,
+        data:  {
+          "accept_license_agreement" => "accepted",
+          "non_emb_ctr"              => "confirmed",
+          "submit"                   => "Download software",
+        }
+
+    pkg "JLink_MacOSX_V#{version.no_dots}_arm64.pkg"
+  end
+
   name "Segger J-Link Command Line Tools"
   desc "Software and Documentation pack for Segger J-Link debug probes"
   homepage "https://www.segger.com/downloads/jlink"
-
-  pkg "JLink_MacOSX_V#{version.no_dots}.pkg"
 
   uninstall quit:    [
     "com.segger.JFlashLite.*",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

