### PR TITLE
safenet-authentication-client: delete redundant `verified`

### DIFF
--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -2,8 +2,7 @@ cask "safenet-authentication-client" do
   version "10.2.109.0"
   sha256 "d0c316379c03e17a35a53e81df641b85b38b5cf7b7a8f6b5f11789a0819f943a"
 
-  url "https://www.globalsign.com/en/safenet-drivers/USB/#{version.major_minor}/Safenet_#{version.major_minor}_Post_GA_R3.zip",
-      verified: "www.globalsign.com/en/safenet-drivers/"
+  url "https://www.globalsign.com/en/safenet-drivers/USB/#{version.major_minor}/Safenet_#{version.major_minor}_Post_GA_R3.zip"
   name "SafeNet Authentication Client"
   desc "Client for smart card readers and security tokens"
   homepage "https://support.globalsign.com/ssl/ssl-certificates-installation/safenet-drivers"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
