### PR TITLE
Update ubiquiti-unifi-controller from 6.0.41 to 6.0.45

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask "ubiquiti-unifi-controller" do
-  version "6.0.41"
-  sha256 "1c1e00585dbcddcd3453cd410ac9c0fc13bf5552087b4f30a6667b0a65f43c00"
+  version "6.0.45"
+  sha256 "8ef5a47fed81daebf4e197ca41a998f65c286ab8fd21f74332c038a753271ab0"
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg",
       verified: "dl.ubnt.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

sha256sum additionally verified on official release notes: https://community.ui.com/releases/UniFi-Network-Controller-6-0-45/8d3b98e1-b9d4-4ab3-b8da-721dbe9ab842

> **Checksums**
> 
> ```
> 4a47b3094ef79ff31240d55f5791da1c *UniFi-installer.exe
> 877fcaea5ff92e2d027050d5baa704e1 *UniFi.pkg
> 7050bf7402aa8a50a647609f6d65dae9 *unifi_sysvinit_all.deb
> 601df32736f41e40a80a3e472450a3e1 *unifi_sh_api
> 
> 
> ------------------------------------------------------------------------------------------------------------------------
> 
> 
> SHA256(UniFi-installer.exe)= dd38e792a601d4cc32192a9d69bbdfccae990a22a16fb0831bd8957d0305a9da
> SHA256(UniFi.pkg)= 8ef5a47fed81daebf4e197ca41a998f65c286ab8fd21f74332c038a753271ab0
> SHA256(unifi_sysvinit_all.deb)= be536b2e1295c14db604a03fe2236303b0ad7927e168039f39d8882bba10f0d6
> SHA256(unifi_sh_api)= 1791685039ea795970bcc7a61eec854058e3e6fc13c52770e31e20f3beb622eb
> ```