### PR TITLE
logitech-options: add additional zap for leftover data

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -37,6 +37,7 @@ cask "logitech-options" do
 
   zap trash: [
     "~/Library/Application Support/Logitech/Logitech Options",
+    "~/Library/Application Support/Logitech/Options",
     "~/Library/Caches/com.logitech.Logi-Options",
     "~/Library/Preferences/com.logitech.Logi-Options.plist",
     "~/Library/Preferences/com.logitech.manager.daemon.plist",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.


**Some leftover data after original zap**
```zsh
❯ fd logitech Library --exclude 'Caches/Homebrew'
Library/Application Support/Logitech

❯ tree "Library/Application Support/Logitech"
Library/Application\ Support/Logitech
└── Options
    └── ble_pids.xml
```