### PR TITLE
Update fujitsu-scansnap-home.rb

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,6 +1,6 @@
 cask "fujitsu-scansnap-home" do
-  version "1.9.1"
-  sha256 "f564193b63a452422b6c6f52c52dd2d106e9ac35e13cb3254a829d69a216dc2e"
+  version "2.0.30"
+  sha256 "2e546eb922e4fc547395f66a02ba35f0ce8133ea858f29a0fa63b6f559025abe"
 
   url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg",
       verified: "origin.pfultd.com/"


### PR DESCRIPTION
updating from 1.9.1 to 2.0.30 with correct(ed) SHA256

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.