### PR TITLE
Update logitech-unifying macos dependency

### DIFF
--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -8,10 +8,15 @@ cask "logitech-unifying" do
   end
 
   url "https://download01.logi.com/web/ftp/pub/controldevices/unifying/unifying#{version}_mac.zip"
-  appcast "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=ec9eb8f1-8e0b-11e9-a62b-5b664cf4d3da"
   name "Logitech Unifying Software"
   desc "Utility for pairing devices with Unifying receivers"
   homepage "https://support.logi.com/hc/en-001/articles/360025297913-Unifying-Software"
+
+  livecheck do
+    url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=ec9eb8f1-8e0b-11e9-a62b-5b664cf4d3da"
+    strategy :page_match
+    regex(/unifying(\d+(?:\.\d+)*)_mac\.zip/i)
+  end
 
   depends_on macos: ">= :yosemite"
 

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -10,16 +10,10 @@ cask "logitech-unifying" do
   url "https://download01.logi.com/web/ftp/pub/controldevices/unifying/unifying#{version}_mac.zip"
   appcast "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=ec9eb8f1-8e0b-11e9-a62b-5b664cf4d3da"
   name "Logitech Unifying Software"
+  desc "Utility for pairing devices with Unifying receivers"
   homepage "https://support.logi.com/hc/en-001/articles/360025297913-Unifying-Software"
 
-  depends_on macos: [
-    :yosemite,
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-    :mojave,
-    :catalina,
-  ]
+  depends_on macos: ">= :yosemite"
 
   pkg "Unifying Installer.app/Contents/Resources/Logitech Unifying Signed.mpkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

The download page referenced in the cask formula does not list Big Sur compatibility, however a Logitech Big Sur compatibility page (https://support.logi.com/hc/en-us/articles/360053649633) says version 1.3.375 of Unifying "has been tested and is fully compatible with Big Sur".
