### PR TITLE
insta360-studio: Update to 3.6.4 and add livecheck

### DIFF
--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -13,10 +13,10 @@ cask "insta360-studio" do
       apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }["items"]
                  .sort_by { |k| k["version"] }.reverse
       macos = apps.find { |item| item["platform"] == "mac" }
-      v1 = macos["version"]
+      v = macos["version"]
       regex = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
       match = macos["channels"][0]["download_url"].match(regex)
-      "#{v1},#{match[3]}:#{match[1]}.#{match[2]}"
+      "#{v},#{match[3]}:#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -1,6 +1,6 @@
 cask "insta360-studio" do
-  version "3.6.2,2021_20210310_020734:20210310.ccdb347864e767b6d9ebb50fd2c4e059"
-  sha256 "1b173dbc63ae40840a8d6403f525103c8808d214e8ca387d4a8d7d769547f01a"
+  version "3.6.4,2021_20210410_171056:20210412.faaa98a3bfa1d724f7ceab610c1aea6b"
+  sha256 "416ffd5108c3c4a4c7f754807ee43a86884eae021f38148349df56a42332f1d8"
 
   url "https://res.insta360.com/static/assets/storage/#{version.after_colon.major}/#{version.after_colon.minor}/Insta360_Studio_#{version.after_comma.before_colon}_signed.pkg"
   name "Insta360 Studio"
@@ -8,7 +8,15 @@ cask "insta360-studio" do
   homepage "https://www.insta360.com/"
 
   livecheck do
-    skip "No version information available"
+    url "https://openapi.insta360.com/website/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
+    strategy :page_match do |page|
+      apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }
+      macos = apps["items"].find { |item| item["platform"] == "mac" }
+      v1 = macos["version"]
+      pattern = %r{.+/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+[._-]\d+[._-]\d+)[._-]signed\.pkg}i
+      match = macos["channels"][0]["download_url"].match(pattern)
+      "#{v1},#{match[3]}:#{match[1]}.#{match[2]}"
+    end
   end
 
   pkg "Insta360_Studio_#{version.after_comma.before_colon}_signed.pkg"

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -11,7 +11,7 @@ cask "insta360-studio" do
     url "https://openapi.insta360.com/website/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
     strategy :page_match do |page|
       apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }["items"]
-                 .sort_by { |k| k["version"] }.reverse!
+                 .sort_by { |k| k["version"] }.reverse
       macos = apps.find { |item| item["platform"] == "mac" }
       v1 = macos["version"]
       pattern = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -11,7 +11,7 @@ cask "insta360-studio" do
     url "https://openapi.insta360.com/website/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
     strategy :page_match do |page|
       apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }["items"]
-      apps.sort_by! { |k| k["version"] }.reverse!
+                 .sort_by { |k| k["version"] }.reverse!
       macos = apps.find { |item| item["platform"] == "mac" }
       v1 = macos["version"]
       pattern = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -1,6 +1,6 @@
 cask "insta360-studio" do
-  version "3.6.4,2021_20210410_171056:20210412.faaa98a3bfa1d724f7ceab610c1aea6b"
-  sha256 "416ffd5108c3c4a4c7f754807ee43a86884eae021f38148349df56a42332f1d8"
+  version "3.6.2,2021_20210310_020734:20210310.ccdb347864e767b6d9ebb50fd2c4e059"
+  sha256 "1b173dbc63ae40840a8d6403f525103c8808d214e8ca387d4a8d7d769547f01a"
 
   url "https://res.insta360.com/static/assets/storage/#{version.after_colon.major}/#{version.after_colon.minor}/Insta360_Studio_#{version.after_comma.before_colon}_signed.pkg"
   name "Insta360 Studio"

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -13,7 +13,7 @@ cask "insta360-studio" do
       apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }
       macos = apps["items"].find { |item| item["platform"] == "mac" }
       v1 = macos["version"]
-      pattern = %r{.+/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+[._-]\d+[._-]\d+)[._-]signed\.pkg}i
+      pattern = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
       match = macos["channels"][0]["download_url"].match(pattern)
       "#{v1},#{match[3]}:#{match[1]}.#{match[2]}"
     end

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -14,8 +14,8 @@ cask "insta360-studio" do
                  .sort_by { |k| k["version"] }.reverse
       macos = apps.find { |item| item["platform"] == "mac" }
       v1 = macos["version"]
-      pattern = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
-      match = macos["channels"][0]["download_url"].match(pattern)
+      regex = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
+      match = macos["channels"][0]["download_url"].match(regex)
       "#{v1},#{match[3]}:#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -1,6 +1,6 @@
 cask "insta360-studio" do
-  version "3.6.2,2021_20210310_020734:20210310.ccdb347864e767b6d9ebb50fd2c4e059"
-  sha256 "1b173dbc63ae40840a8d6403f525103c8808d214e8ca387d4a8d7d769547f01a"
+  version "3.6.4,2021_20210412_145507:20210412.bc8d698e971ae16f2517bc3e3c581278"
+  sha256 "8369259ce47cb23e9ae40c378636fdcf2bb91e179a781e80768399613147bd26"
 
   url "https://res.insta360.com/static/assets/storage/#{version.after_colon.major}/#{version.after_colon.minor}/Insta360_Studio_#{version.after_comma.before_colon}_signed.pkg"
   name "Insta360 Studio"

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -10,8 +10,9 @@ cask "insta360-studio" do
   livecheck do
     url "https://openapi.insta360.com/website/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
     strategy :page_match do |page|
-      apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }
-      macos = apps["items"].find { |item| item["platform"] == "mac" }
+      apps = JSON.parse(page)["data"]["apps"].find { |app| app["id"] == 38 }["items"]
+      apps.sort_by! { |k| k["version"] }.reverse!
+      macos = apps.find { |item| item["platform"] == "mac" }
       v1 = macos["version"]
       pattern = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
       match = macos["channels"][0]["download_url"].match(pattern)


### PR DESCRIPTION
Update insta360-studio from 3.6.2,2021_20210310_020734:20210310.ccdb347864e767b6d9ebb50fd2c4e059 to 3.6.4,2021_20210410_171056:20210412.faaa98a3bfa1d724f7ceab610c1aea6b

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
