### PR TITLE
elecom-mouse-assistant: update from 5.2.1.002 to 5.2.2.002 and add livecheck

### DIFF
--- a/Casks/elecom-mouse-assistant.rb
+++ b/Casks/elecom-mouse-assistant.rb
@@ -1,12 +1,19 @@
 cask "elecom-mouse-assistant" do
-  version "5.2.1.002"
-  sha256 "4105ba47f41fc874929e1aeb10f9a123fe24809e1502c24b08d2a801e0498b2c"
+  version "5.2.2.002"
+  sha256 "eb0e6679efc3a71ea617b2e610a06bf535eada8816ff7e274f70f66e22b65341"
 
   url "https://dl.elecom.co.jp/support/download/peripheral/mouse/assistant/mac/ELECOM_Mouse_Installer_#{version}.zip"
-  appcast "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
   name "ELECOM Mouse Assistant"
   desc "Software to more effectively use an ELECOM mouse"
   homepage "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/"
+
+  livecheck do
+    url "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
+    strategy :page_match
+    regex(/ELECOM_Mouse_Installer_(\d+(?:\.\d+)*)\.zip/i)
+  end
+
+  depends_on macos: ">= :el_capitan"
 
   pkg "ELECOM_Mouse_Installer_#{version}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

`depends_on` from: https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/
```
* "ELECOM Mouse Assistant for Macintosh" has ended OS support before "macOS El Capitan (10.11)".
* If you are using an OS earlier than "macOS El Capitan (10.11)", please use this older version (5.1.13.000).
```