### PR TITLE
fender-fuse: discontinued on March 20, 2020

### DIFF
--- a/Casks/fender-fuse.rb
+++ b/Casks/fender-fuse.rb
@@ -24,4 +24,8 @@ cask "fender-fuse" do
             delete:  "/Applications/Fender FUSE.app"
 
   zap trash: "~/Library/Application Support/Microsoft/Silverlight/OutOfBrowser/*.localhost"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

---

Alternatively, can remove Cask.

https://fuse.fender.com/
> **Effective March 20, 2020 Fender® FUSE™ has been discontinued.**
> **IMPORTANT: PLEASE READ!**
> 
> ---
> 
> Effective March 20, 2020 Fender® FUSE™ has been discontinued.
> 
> Fender® FUSE™ is no longer actively supported by Fender.