### PR TITLE
concept2-utility: add livecheck and set min OS 10.13

### DIFF
--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -1,5 +1,5 @@
 cask "concept2-utility" do
-  if MacOS.version <= :el_capitan
+  if MacOS.version <= :sierra
     version "7.09.02"
     sha256 "e4ebee8cde57c7ef63c3903285c3fc0ee8f87221e7c5529b9dcf97b3f9ebb57e"
   else
@@ -8,11 +8,15 @@ cask "concept2-utility" do
   end
 
   url "https://software.concept2.com/utility/Concept2Utility#{version.no_dots}.dmg"
-  appcast "https://www.concept2.com/service/software/concept2-utility",
-          must_contain: version.no_dots
   name "Concept2 Utility"
   desc "Utilities for the Concept2 Performance Monitor"
   homepage "https://www.concept2.com/service/software/concept2-utility"
+
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(/Concept2\s+Utility\s+(\d+(?:\.\d+)*)/i)
+  end
 
   depends_on macos: ">= :yosemite"
 

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -15,7 +15,7 @@ cask "concept2-utility" do
   livecheck do
     url :homepage
     strategy :page_match
-    regex(/Concept2\s*Utility\s*(\d+(?:\.\d+)*)/i)
+    regex(/Concept2\s+Utility\s+(\d+(?:\.\d+)*)/i)
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -15,7 +15,7 @@ cask "concept2-utility" do
   livecheck do
     url :homepage
     strategy :page_match
-    regex(/Concept2\s+Utility\s+(\d+(?:\.\d+)*)/i)
+    regex(/Concept2\s*Utility\s*(\d+(?:\.\d+)*)/i)
   end
 
   depends_on macos: ">= :yosemite"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://www.concept2.com/service/software/concept2-utility

> **Macintosh System Requirements**
> MacOS 10.13 or later
> ...
> OS X 10.12 and Earlier
> If running OS X 10.12 or earlier, the most recent working version of the Utility is 7.09.2. 