### PR TITLE
zsa-wally: fix livecheck to only get osx version

### DIFF
--- a/Casks/zsa-wally.rb
+++ b/Casks/zsa-wally.rb
@@ -4,9 +4,14 @@ cask "zsa-wally" do
 
   url "https://github.com/zsa/wally/releases/download/#{version}-osx/wally-osx-#{version}.dmg",
       verified: "github.com/zsa/wally/"
-  appcast "https://github.com/zsa/wally/releases.atom"
   name "Wally"
+  desc "Flash tool for ZSA keyboards"
   homepage "https://ergodox-ez.com/pages/wally"
+
+  livecheck do
+    url "https://configure.ergodox-ez.com/wally/osx"
+    strategy :header_match
+  end
 
   app "Wally.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Original GitHub check gets Linux/etc versions:
```console
❯ brew livecheck zsa-wally
zsa-wally : 2.1.0 ==> 2.1.1-linux
```

Switch to link on homepage that redirects to GitHub.