### PR TITLE
logitech-myharmony: discontinued as 32-bit app

### DIFF
--- a/Casks/logitech-myharmony.rb
+++ b/Casks/logitech-myharmony.rb
@@ -5,11 +5,22 @@ cask "logitech-myharmony" do
   url "https://app.myharmony.com/prod/mac/#{version.major_minor}/MyHarmony-App.dmg"
   appcast "https://app.myharmony.com/prod/mac/harmonycast.xml"
   name "MyHarmony"
+  desc "Configuration software for Logitech Harmony universal remote control"
   homepage "https://setup.myharmony.com/"
+
+  depends_on macos: "<= :mojave"
 
   pkg "MyHarmonySetup.pkg"
 
   uninstall quit:    "org.logitech.MyHarmony",
             pkgutil: "MyHarmony.pkg",
             rmdir:   "/Applications/MyHarmony.app"
+
+  caveats do
+    discontinued
+    <<~EOS
+      MyHarmony is a 32-bit app and will not run on macOS 10.15 & above.
+      It has been deprecated in favor of Harmony Desktop app and mobile app.
+    EOS
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Resource: https://support.myharmony.com/en-us/download
> If you are on macOS 10.14 or below and plan to upgrade to macOS Big Sur, you will not be able to use **MyHarmony** any longer because it is a 32 bit application that is not compatible with the latest versions of macOS. You will have to download and use **Harmony Desktop App**. Please note that Harmony Desktop App does not support Hub based remotes. If you have a Hub based remote, you will need to download the **Harmony mobile app** from the Apple App Store or Google Play Store.