### PR TITLE
Update blue-sherpa from 20200810 to 20210121 and add livecheck

### DIFF
--- a/Casks/blue-sherpa.rb
+++ b/Casks/blue-sherpa.rb
@@ -1,12 +1,19 @@
 cask "blue-sherpa" do
-  version "20200810"
-  sha256 "f1287b3b32007620f36bc1d49bc1f8cfb7347e228e34fa3b07904b186fbfcf64"
+  version "20210121"
+  sha256 "42632547bdf69fb979b31cc08e601fd5805b638259e2e9e916b865f0893ed8ba"
 
   url "https://software.bluemic.com/blue/BlueSherpa-#{version}.pkg"
-  appcast "https://www.bluemic.com/en-us/products/sherpa/"
   name "Blue Sherpa"
   desc "Companion app for Blue USB microphones"
   homepage "https://www.bluemic.com/en-us/products/sherpa/"
+
+  livecheck do
+    url "https://software.bluemic.com/blue/"
+    strategy :page_match
+    regex(/href=.*?BlueSherpa-(\d+)\.pkg/i)
+  end
+
+  depends_on macos: ">= :high_sierra"
 
   # pkg cannot be installed automatically
   installer manual: "BlueSherpa-#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://www.bluemic.com/en-us/products/sherpa/
> macOS 10.13 or higher
> Currently not compatible with macOS 11 Big Sur

Also, homepage links version `1.5.150 (== 20210121)`, but old semantic versions are not archived, so using date version.