### PR TITLE
sonos: add livecheck

### DIFF
--- a/Casks/sonos.rb
+++ b/Casks/sonos.rb
@@ -1,12 +1,16 @@
 cask "sonos" do
-  version "13.0"
+  version "13.0,62.1.86220"
   sha256 "f4a0112cbd5b8340ca25e6349daa8000690dd80f182702bdc399787e0e861101"
 
-  url "https://update.sonos.com/software/mac/mdcr/SonosDesktopController#{version.no_dots}.dmg"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.sonos.com/en/redir/controller_software_mac2",
-          must_contain: version.no_dots
+  url "https://update.sonos.com/software/mac/mdcr/SonosDesktopController#{version.before_comma.no_dots}.dmg"
   name "Sonos"
+  desc "Control your Sonos system"
   homepage "https://www.sonos.com/"
+
+  livecheck do
+    url "https://www.sonos.com/en/redir/controller_software_mac2"
+    strategy :extract_plist
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes
Couldn't find a better option than `extract_plist`
- A `header_match` would only get undotted version `130`
- Sonos site uses too many scripts so I couldn't do `page_match` on https://support.sonos.com/s/article/3521?language=en_US
