### PR TITLE
Update hhkb-pro-driver from 5.0.1 to 5.1 and add livecheck

### DIFF
--- a/Casks/hhkb-pro-driver.rb
+++ b/Casks/hhkb-pro-driver.rb
@@ -1,11 +1,19 @@
 cask "hhkb-pro-driver" do
-  version "5.0.1"
-  sha256 "908a09868935ea67b527f8909c61b53b1e3e5b084cc8ac2cdc2db81436d7717f"
+  version "5.1"
+  sha256 "08518539c02e6dae7ee93f4188be9665e8c2b1e33f0fea681fa6cfc4dffc383b"
 
   url "https://www.pfu.fujitsu.com/hhkeyboard/downloads/HHKBProDriver#{version}.dmg"
   name "PFU Happy Hacking Keyboard Professional Driver"
   desc "Driver for HHKB Professional"
   homepage "https://www.pfu.fujitsu.com/hhkeyboard/macdownload.html"
+
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(%r{href=.*?/HHKBProDriver(\d+(?:\.\d+)*)\.dmg}i)
+  end
+
+  depends_on macos: ">= :big_sur"
 
   app "HHKB Pro Driver.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

HHKB driver v5 min version = macOS 11