### PR TITLE
bose-soundtouch: add livecheck

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -38,7 +38,10 @@ cask "bose-soundtouch" do
   },
             signal:    ["TERM", "com.Bose.SoundTouch"],
             quit:      "io.qt.SoundTouchHelper",
-            launchctl: "com.Bose.SoundTouch"
+            launchctl: [
+              "com.Bose.SoundTouch",
+              "application.com.Bose.SoundTouch",
+            ]
 
   zap trash: [
     "~/Library/Application Support/SoundTouch",

--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -3,10 +3,25 @@ cask "bose-soundtouch" do
   sha256 "be74aeaa1e73bd6b07d92ceb5fcff5b58c4023eb7ccdb034fea842080554aa4e"
 
   url "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
-  appcast "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/index.xml"
   name "Bose Soundtouch Controller App"
   desc "Control Bose SoundTouch systems from your computer"
   homepage "https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html"
+
+  # The first-party download page uses JavaScript to render the content. The
+  # URL below redirects to the XML file containing release information that's
+  # used as the data source for the download page.
+  livecheck do
+    url "https://worldwide.bose.com/updates/soundtouch"
+    regex(%r{
+      <RELEASE [^>]*?URLPATH=["']/ced/soundtouch/([^/]+)/?["'][^>]*?>\s*
+      <IMAGE [^>]*?FILENAME=["']SoundTouch-app-installer-(\d+(?:\.\d+)+(?:-[a-z\d]+)+)\.dmg["']
+    }ix)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        "#{match[1]},#{match[0]}"
+      end
+    end
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

This PR replaces the `appcast` with a `livecheck` block that checks the XML file that's used as the data source for the [first-party download page](https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html). The download page uses JavaScript for client-side rendering (i.e., the HTML doesn't contain version information) and the XML file is where the version information is actually found.

It's worth noting that I'm using the `https://worldwide.bose.com/updates/soundtouch` URL, as it redirects to the latest XML file. The XML file URL is version specific (e.g., `https://downloads.bose.com/ced/soundtouch/st3_2020_a3b99494/index.xml`), so the previous appcast URL was seemingly checking the existing cask version instead of new versions.

The regex for this `livecheck` block is quite lengthy and had to be split using the `x` flag to pass `brew style`. This regex is necessary at the moment but hopefully this is just a short-term thing. Once I've finished up some livecheck PRs in homebrew/brew, I'm aiming to add an XML strategy (along with a JSON strategy) to parse the XML and provide that to a `strategy` block. This should allow us to target elements more reliably and parse attributes in a saner way. That's something for the future but I figured I would mention it, at least.