### PR TITLE
Update logitech-firmwareupdatetool from 2.0.47973 to 2.5.108413

### DIFF
--- a/Casks/logitech-firmwareupdatetool.rb
+++ b/Casks/logitech-firmwareupdatetool.rb
@@ -1,13 +1,18 @@
 cask "logitech-firmwareupdatetool" do
-  version "2.0.47973"
-  sha256 :no_check
+  version "2.5.108413"
+  sha256 "f0ed92065102d96c45e0819e37bc82baf09b9997b06eb21c16d5abfe70e09e0c"
 
-  url "https://download01.logi.com/web/ftp/pub/techsupport/keyboards/FirmwareUpdateToolInstaller.zip"
-  appcast "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=07d54a46-c89d-11e9-9981-4556732441db"
+  url "https://download01.logi.com/web/ftp/pub/techsupport/keyboards/FirmwareUpdateToolInstaller_#{version}.zip"
   name "Logitech Firmware Update Tool"
+  desc "Update your Logitech wireless receivers and selected keyboards"
   homepage "https://support.logi.com/hc/en-us/articles/360035037273"
 
-  container nested: "FirmwareUpdateTool/FirmwareUpdateTool.zip"
+  livecheck do
+    url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=07d54a46-c89d-11e9-9981-4556732441db"
+    regex(%r{/FirmwareUpdateToolInstaller[._-]?(\d+(?:\.\d+)+)\.zip}i)
+  end
+
+  depends_on macos: ">= :high_sierra"
 
   app "FirmwareUpdateTool.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
