### PR TITLE
wacom-tablet: add livecheck

### DIFF
--- a/Casks/wacom-tablet.rb
+++ b/Casks/wacom-tablet.rb
@@ -3,10 +3,16 @@ cask "wacom-tablet" do
   sha256 "8d5fde477cd33636d9334d577f3f25647183a51b6ee1de3f7ccb27cda053e9cc"
 
   url "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
-  appcast "https://www.wacom.com/en-de/support/product-support/drivers"
   name "Wacom Tablet"
   desc "Resources for Wacom tablets"
   homepage "https://www.wacom.com/en-us/support/product-support/drivers"
+
+  livecheck do
+    url :homepage
+    regex(%r{/WacomTablet[._-]?(\d+(?:\.\d+)+(?:[_-]\d+)?)\.dmg}i)
+  end
+
+  depends_on macos: ">= :high_sierra"
 
   pkg "Install Wacom Tablet.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://www.wacom.com/en-us/support/product-support/drivers#latest
> Driver 6.3.42-1 (macOS 10.13 - 11) - 111 MB

---

```console
❯ brew audit --online --cask wacom-tablet
==> Downloading https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_6.3.42-1.dmg
######################################################################## 100.0%
audit for wacom-tablet: passed

❯ brew livecheck --debug wacom-tablet
git config --get homebrew.devcmdrun

Cask:             wacom-tablet
Livecheckable?:   Yes

URL (homepage):   https://www.wacom.com/en-us/support/product-support/drivers
Strategy:         PageMatch
Regex:            /\/WacomTablet[._-]?(\d+(?:\.\d+)+(?:[_-]\d+)?)\.dmg/i

Matched Versions:
6.3.42-1, 6.3.41-2, 6.3.40-2, 6.3.39-1, 6.3.38-3, 6.3.37-3, 6.3.36-2, 6.3.35-2, 6.3.34-2, 6.3.33-5, 6.3.32-4, 6.3.31-6, 6.3.29-6, 6.3.28-2, 6.3.27-2, 6.3.25-2, 6.3.24-1, 6.3.23-4, 6.3.22-3, 6.3.21-8, 6.3.20-11, 6.3.19-10, 6.3.18-4, 6.3.17-5, 6.3.16-12, 6.3.15-3, 6.3.14-2, 6.3.8-2, 6.3.7-1, 6.3.6-4, 6.3.5-3, 6.3.4-3, 6.3.3-3, 6.3.2-4, 6.1.7-5, 6.1.6-4, 4.96-3
wacom-tablet : 6.3.42-1 ==> 6.3.42-1
```