### PR TITLE
Update HuionTablet Mac Driver from v14.6.0.210128 to v15.4.1.143

### DIFF
--- a/Casks/huiontablet.rb
+++ b/Casks/huiontablet.rb
@@ -1,6 +1,6 @@
 cask "huiontablet" do
-  version "14.6.0.210128"
-  sha256 "6f99a9640e8853d9d46f91ec134cc2aee65fc4d4fff340b3310793f606dfef56"
+  version "15.4.1.143"
+  sha256 "bc5acb56578b0e7b9a87e90e37f44004b3b2a4b21b11b042015161222504cdeb"
 
   url "https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_v#{version}.zip"
   name "Huion Tablet"

--- a/Casks/huiontablet.rb
+++ b/Casks/huiontablet.rb
@@ -2,12 +2,10 @@ cask "huiontablet" do
   version "15.4.1.143"
   sha256 "bc5acb56578b0e7b9a87e90e37f44004b3b2a4b21b11b042015161222504cdeb"
 
-  url "https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_v#{version}.zip"
+  url "https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_v#{version}.dmg"
   name "Huion Tablet"
   desc "Driver for Huion Tablets"
   homepage "https://huion.com/"
-
-  container nested: "HuionTablet_MacDriver_v#{version}.dmg"
 
   app "HuionTablet.app"
 

--- a/Casks/huiontablet.rb
+++ b/Casks/huiontablet.rb
@@ -7,6 +7,12 @@ cask "huiontablet" do
   desc "Driver for Huion Tablets"
   homepage "https://huion.com/"
 
+  livecheck do
+    url "https://huion.com/download/"
+    strategy :page_match
+    regex(/HuionTablet_MacDriver_v?(\d+(?:\.\d+)*)\.dmg/i)
+  end
+
   app "HuionTablet.app"
 
   zap trash: "~/Library/Saved Application State/com.huion.HuionTablet.savedState"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
