### PR TITLE
dependabot: ignore updates to `actions/stale` and `dessant/lock-threads`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # The actions in triage-issues.yml are updated in the Homebrew/.github repo
+    ignore:
+      - dependency-name: actions/stale
+      - dependency-name: dessant/lock-threads


### PR DESCRIPTION

See https://github.com/Homebrew/brew/issues/11401

These actions should be updated by dependabot in Homebrew/.github so, to avoid extra PRs, let's ignore them here.