### PR TITLE
Update "Silicon Labs VCP Driver" from 6.0 to 6.0.1

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,5 +1,5 @@
 cask "silicon-labs-vcp-driver" do
-  version "6.0"
+  version "6.0.1"
   sha256 :no_check
 
   url "https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip"


### PR DESCRIPTION
The changelog for this new version :

>	 On macOS Big Sur: 	
>		- Fix issue with CP2105 that it cannot transfer data if Software flow control is enabled.
>		- Fix installation error under some conditions.
>
>	On macOS Catalina or older: 	
>		- Add support for Line Break to the driver.
>		- Fix RTS doesn't go high if host PC buffer is full.
>		- Improve throughput.

The download url of the installer has not changed.