### PR TITLE
Add XP-Pen PenTablet drivers v3.1.1

### DIFF
--- a/Casks/xppen-pentablet.rb
+++ b/Casks/xppen-pentablet.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+cask "xppen-pentablet" do
+  version "3.1.1_210507"
+  sha256 "335c01a6483f259a45b330a2a6e545f77550682326bd82d65bfb0c5ea512e104"
+
+  url "https://www.xp-pen.com/download/file/id/1968"
+  name "XP-Pen PenTablet"
+  desc "Driver and configuration app for XP-Pen graphic tablets"
+  homepage "https://www.xp-pen.com/"
+
+  container nested: "XP-PENMac_#{version}/XP-PENMac_#{version}.dmg"
+
+  app "XP-PenPenTabletPro/PenTablet.app"
+end

--- a/Casks/xppen-pentablet.rb
+++ b/Casks/xppen-pentablet.rb
@@ -10,6 +10,7 @@ cask "xppen-pentablet" do
   livecheck do
     url :url
     strategy :header_match
+    regex(/XP-PENMac_(\d+(?:.\d+)*)\.zip/i)
   end
 
   container nested: "XP-PENMac_#{version}/XP-PENMac_#{version}.dmg"

--- a/Casks/xppen-pentablet.rb
+++ b/Casks/xppen-pentablet.rb
@@ -1,13 +1,16 @@
-# frozen_string_literal: true
-
 cask "xppen-pentablet" do
   version "3.1.1_210507"
-  sha256 "335c01a6483f259a45b330a2a6e545f77550682326bd82d65bfb0c5ea512e104"
+  sha256 :no_check
 
   url "https://www.xp-pen.com/download/file/id/1968"
   name "XP-Pen PenTablet"
   desc "Driver and configuration app for XP-Pen graphic tablets"
   homepage "https://www.xp-pen.com/"
+
+  livecheck do
+    url :url
+    strategy :header_match
+  end
 
   container nested: "XP-PENMac_#{version}/XP-PENMac_#{version}.dmg"
 

--- a/Casks/xppen-pentablet.rb
+++ b/Casks/xppen-pentablet.rb
@@ -12,4 +12,11 @@ cask "xppen-pentablet" do
   container nested: "XP-PENMac_#{version}/XP-PENMac_#{version}.dmg"
 
   app "XP-PenPenTabletPro/PenTablet.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.ugee.uninstallpen.plist",
+    "~/Library/Saved Application State/com.ugee.PenTablet2.0.savedState",
+    "/Library/Application Support/PenDriver",
+    "~/.PenTablet",
+  ]
 end


### PR DESCRIPTION
XP-Pen graphic tablet drivers.
Tested with XP-Pen Star G640. In theory, works with a large range of XP-Pen tablets (not sure if all of them or not).

Known issues:
- `brew audit` reports 1 error ("Use `sha256 :no_check` when URL is unversioned), but URL _is_ actually versioned: this is a unique URL for this version (`file/id/1968`), even though it does not contain the version number (if you think that the sha256 should be set as `no_check`, let me know).
- The DMG container also contains an uninstaller: `XP-PenPenTabletPro/UninstallPenTablet.app`. I'm not sure if this should be "installed" together? (I have not found instructions in Homebrew about this case). And also not sure whether/how it should be used for uninstalling or not.

Checks:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
