### PR TITLE
Updated Huion Tablet Mac OS Driver to v15.4.8.172 released on 20210531

### DIFF
--- a/Casks/huiontablet.rb
+++ b/Casks/huiontablet.rb
@@ -1,6 +1,6 @@
 cask "huiontablet" do
-  version "15.4.1.143"
-  sha256 "bc5acb56578b0e7b9a87e90e37f44004b3b2a4b21b11b042015161222504cdeb"
+  version "15.4.8.172"
+  sha256 "e0a1f93ae7fced023304005c34962757f073a4979ac8735e85ca3aade3afaf5f"
 
   url "https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_v#{version}.dmg"
   name "Huion Tablet"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
