### PR TITLE
acs-acr39u-smartcard-driver: add livecheck

### DIFF
--- a/Casks/acs-acr39u-smartcard-driver.rb
+++ b/Casks/acs-acr39u-smartcard-driver.rb
@@ -1,14 +1,23 @@
 cask "acs-acr39u-smartcard-driver" do
-  version "1.1.8.2"
+  version "1.1.8.2,12835"
   sha256 "adf059f1963b6d2419ac0904b87ca9d92d72b81a6911439eff577c6ba42ad4ca"
 
-  url "https://www.acs.com.hk/download-driver-unified/12835/ACS-Unified-INST-MacOSX-#{version.no_dots}-P.zip"
-  appcast "https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/"
+  url "https://www.acs.com.hk/download-driver-unified/#{version.after_comma}/ACS-Unified-INST-MacOSX-#{version.before_comma.no_dots}-P.zip"
   name "ACS Unified Installer"
   desc "PC/SC driver for ACR39U smart card reader"
   homepage "https://www.acs.com.hk/en/driver/302/acr39u-smart-card-reader/"
 
-  container nested: "acsccid_installer-#{version}.dmg"
+  livecheck do
+    url :homepage
+    regex(%r{href=["']?[^"' >]*?/(\d+)/ACS-Unified-INST-MacOSX-(\d+)-P\.zip.*?Version\s*(\d+(?:\.\d+)+)}im)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        "#{match[2]},#{match[0]}" if match[1] == match[2].tr(".", "")
+      end.compact
+    end
+  end
+
+  container nested: "acsccid_installer-#{version.before_comma}.dmg"
 
   pkg "acsccid_installer.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Not ideal `livecheck` due to needing to capture across multiple lines, e.g.
```html
<td width="60%">
	<span class="title"><a href="/download-driver-unified/12835/ACS-Unified-INST-MacOSX-1182-P.zip" title="PC/SC Driver Installer">PC/SC Driver Installer</a>&nbsp;</span>
	<span class="sub"><b><i>260.30 KB</i></b></span><br>
	<span class="sub"><b><i>Version 1.1.8.2</i></b></span><br>
	<span class="sub"><i>12-Jan-2021</i></span>
</td>
```

Perhaps an XML/HTML parser would help here.

The equality check is done to avoid false positives in the case that the regex breaks.

---

Also add number in URL to version number since it has changed on previous updates.