### PR TITLE
Update ricoh-ps-printers-vol3-exp-driver to 3.9.0.0

### DIFF
--- a/Casks/ricoh-ps-printers-vol3-exp-driver.rb
+++ b/Casks/ricoh-ps-printers-vol3-exp-driver.rb
@@ -1,14 +1,19 @@
 cask "ricoh-ps-printers-vol3-exp-driver" do
-  version "3.9.0.0"
+  version "3.9.0.0,0001316460"
   sha256 "2a092e94f8abb664fb9fd1512135a53d0ff44ba9d0bcea89a364aebffda936a2"
 
-  url "https://support.ricoh.com/bb/pub_e/dr_ut_e/0001316/0001316460/V#{version.delete(".")}/Ricoh_PS_Printers_Vol3_EXP_LIO_#{version}.dmg"
+  url "https://support.ricoh.com/bb/pub_e/dr_ut_e/#{version.after_comma[0..6]}/#{version.after_comma}/V#{version.before_comma.no_dots}/Ricoh_PS_Printers_Vol3_EXP_LIO_#{version.before_comma}.dmg"
   name "Ricoh PS printers Vol 3 EXP driver"
+  desc "Allow PS driver to control the print device and enable full functionality"
   homepage "https://support.ricoh.com/bb/html/dr_ut_e/apc/model/mpc2011/mpc2011.htm"
 
   livecheck do
     url "https://support.ricoh.com/bb/html/dr_ut_e/apc/model/mpc2011/mpc2011en.htm"
-    regex(/href=.*Ricoh_PS_Printers_Vol3_EXP_LIO_(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/(\d+)/V\d+/Ricoh_PS_Printers_Vol3_EXP_LIO[._-]v?(\d+(?:\.\d+)+)\.dmg}i).map do |match|
+        "#{match[1]},#{match[0]}"
+      end
+    end
   end
 
   pkg "Ricoh_PS_Printers_Vol3_EXP_LIO_Driver.pkg"

--- a/Casks/ricoh-ps-printers-vol3-exp-driver.rb
+++ b/Casks/ricoh-ps-printers-vol3-exp-driver.rb
@@ -21,6 +21,10 @@ cask "ricoh-ps-printers-vol3-exp-driver" do
     "ricoh.commandfilter.pkg",
     "ricoh.copycontrol.pkg",
     "ricoh.cupsfilter.pkg",
+    "ricoh.gencupsfilter.pkg",
+    "ricoh.genjoblog.pkg",
+    "ricoh.genuserAuthentication.pkg",
     "ricoh.joblog.pkg",
+    "ricoh.userAuthentication.pkg",
   ]
 end

--- a/Casks/ricoh-ps-printers-vol3-exp-driver.rb
+++ b/Casks/ricoh-ps-printers-vol3-exp-driver.rb
@@ -6,6 +6,11 @@ cask "ricoh-ps-printers-vol3-exp-driver" do
   name "Ricoh PS printers Vol 3 EXP driver"
   homepage "https://support.ricoh.com/bb/html/dr_ut_e/apc/model/mpc2011/mpc2011.htm"
 
+  livecheck do
+    url "https://support.ricoh.com/bb/html/dr_ut_e/apc/model/mpc2011/mpc2011en.htm"
+    regex(/href=.*Ricoh_PS_Printers_Vol3_EXP_LIO_(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
   pkg "Ricoh_PS_Printers_Vol3_EXP_LIO_Driver.pkg"
 
   uninstall pkgutil: [

--- a/Casks/ricoh-ps-printers-vol3-exp-driver.rb
+++ b/Casks/ricoh-ps-printers-vol3-exp-driver.rb
@@ -1,8 +1,8 @@
 cask "ricoh-ps-printers-vol3-exp-driver" do
-  version "3.4.0.0"
-  sha256 "283e4e27e6544ea6c21d1c9c8523636114c72bb70460ef652cf0765cd0c3756d"
+  version "3.9.0.0"
+  sha256 "2a092e94f8abb664fb9fd1512135a53d0ff44ba9d0bcea89a364aebffda936a2"
 
-  url "https://support.ricoh.com/bb/pub_e/dr_ut_e/0001310/0001310159/V#{version.delete(".")}/Ricoh_PS_Printers_Vol3_EXP_LIO_#{version}.dmg"
+  url "https://support.ricoh.com/bb/pub_e/dr_ut_e/0001316/0001316460/V#{version.delete(".")}/Ricoh_PS_Printers_Vol3_EXP_LIO_#{version}.dmg"
   name "Ricoh PS printers Vol 3 EXP driver"
   homepage "https://support.ricoh.com/bb/html/dr_ut_e/apc/model/mpc2011/mpc2011.htm"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask ricoh-ps-printers-vol3-exp-driver` is error-free. (1 preexisting warning)
- [x] `brew style --fix ricoh-ps-printers-vol3-exp-driver` reports no offenses.