### PR TITLE
Add KensingtonWorks v2.2.10

### DIFF
--- a/Casks/kensingtonworks.rb
+++ b/Casks/kensingtonworks.rb
@@ -1,0 +1,34 @@
+cask "kensingtonworks" do
+  version "2.2.10"
+  sha256 "b3b8190703272e9cb4c1d27b165a63227a4f16a33ff5b130ab15f51a6eb95d66"
+
+  url "https://www.kensington.com/siteassets/software-support/kensingtonworks/new-kensingtonworks-download/kensingtonworks_#{version}.pkg"
+  name "KensingtonWorks"
+  desc "Software to personalise Kensingtons trackballs, mice, and presenters"
+  homepage "https://www.kensington.com/software/kensingtonworks/"
+
+  pkg "kensingtonworks_#{version}.pkg"
+
+  uninstall launchctl: "com.kensington.trackballworks",
+            quit:      [
+              "com.kensington.kensingtonworks2.app",
+              "com.kensington.kensingtonworks2.helper2",
+              "com.kensington.tbwDKDriver",
+              "com.kensington.tbwdkmanager",
+            ],
+            script:    {
+              executable: "/Applications/Utilities/KensingtonWorks Uninstaller.app/Contents/MacOS/KensingtonWorks Uninstaller",
+            },
+            pkgutil:   [
+              "com.kensington.trackballworks2.installer",
+            ],
+            delete:    [
+              "/Library/Application Support/Kensington",
+              "~/Library/Application Support/KensingtonWorks",
+              "~/Library/Logs/KensingtonWorks",
+            ]
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/kensingtonworks.rb
+++ b/Casks/kensingtonworks.rb
@@ -4,8 +4,13 @@ cask "kensingtonworks" do
 
   url "https://www.kensington.com/siteassets/software-support/kensingtonworks/new-kensingtonworks-download/kensingtonworks_#{version}.pkg"
   name "KensingtonWorks"
-  desc "Software to personalise Kensingtons trackballs, mice, and presenters"
+  desc "Software to personalize Kensingtons trackballs, mice, and presenters"
   homepage "https://www.kensington.com/software/kensingtonworks/"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?kensingtonworks[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+  end
 
   pkg "kensingtonworks_#{version}.pkg"
 
@@ -16,18 +21,17 @@ cask "kensingtonworks" do
               "com.kensington.tbwDKDriver",
               "com.kensington.tbwdkmanager",
             ],
-            kext:      [
-              "/Library/Extensions/trackballworks2.kext",
-            ],
+            kext:      "/Library/Extensions/trackballworks2.kext",
             pkgutil:   [
               "com.kensington.trackballworks2",
               "com.kensington.trackballworks2.installer",
-            ],
-            delete:    [
-              "/Library/Application Support/Kensington",
-              "~/Library/Application Support/KensingtonWorks",
-              "~/Library/Logs/KensingtonWorks",
             ]
+
+  zap trash: [
+    "/Library/Application Support/Kensington",
+    "~/Library/Application Support/KensingtonWorks",
+    "~/Library/Logs/KensingtonWorks",
+  ]
 
   caveats do
     reboot

--- a/Casks/kensingtonworks.rb
+++ b/Casks/kensingtonworks.rb
@@ -16,10 +16,11 @@ cask "kensingtonworks" do
               "com.kensington.tbwDKDriver",
               "com.kensington.tbwdkmanager",
             ],
-            script:    {
-              executable: "/Applications/Utilities/KensingtonWorks Uninstaller.app/Contents/MacOS/KensingtonWorks Uninstaller",
-            },
+            kext:      [
+              "/Library/Extensions/trackballworks2.kext",
+            ],
             pkgutil:   [
+              "com.kensington.trackballworks2",
               "com.kensington.trackballworks2.installer",
             ],
             delete:    [

--- a/Casks/kensingtonworks.rb
+++ b/Casks/kensingtonworks.rb
@@ -12,6 +12,9 @@ cask "kensingtonworks" do
     regex(/href=.*?kensingtonworks[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
+  conflicts_with cask: "homebrew/cask-drivers/kensington-trackball-works"
+  depends_on macos: ">= :sierra"
+
   pkg "kensingtonworks_#{version}.pkg"
 
   uninstall launchctl: "com.kensington.trackballworks",

--- a/Casks/kensingtonworks.rb
+++ b/Casks/kensingtonworks.rb
@@ -4,7 +4,7 @@ cask "kensingtonworks" do
 
   url "https://www.kensington.com/siteassets/software-support/kensingtonworks/new-kensingtonworks-download/kensingtonworks_#{version}.pkg"
   name "KensingtonWorks"
-  desc "Software to personalize Kensingtons trackballs, mice, and presenters"
+  desc "Software to personalize Kensington trackballs, mice, and presenters"
   homepage "https://www.kensington.com/software/kensingtonworks/"
 
   livecheck do


### PR DESCRIPTION
KensingtonWorks v2.2.10

Kensington TrackballWorks is deprecated and there company has introduced KensingtonWorks.
This application supports macOS 10.12 to macOS 11 on both Intel and Apple Silicon Macs.

Since Kensington TrackballWorks and KensingtonWorks are he different trademarks, and TrackballWorks supports macOS 10.11 ([Web Archive 20190705](https://web.archive.org/web/20190705123821/https://www.kensington.com/software/trackballworks-customization-software/)), I have created another Cask for the new one instead renaming or replacing the old `homebrew-cask-drivers/kensington-trackball-works` in order to remain the ability to customise Kensington legacy devices and the user should choose either KensingtonWorks or Kensington TrackballWorks on his/her preferences.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
