### PR TITLE
Mark kensington-trackball-works as discontinued

### DIFF
--- a/Casks/kensington-trackball-works.rb
+++ b/Casks/kensington-trackball-works.rb
@@ -4,7 +4,17 @@ cask "kensington-trackball-works" do
 
   url "https://www.kensington.com/siteassets/software-support/trackballworks-#{version}.dmg"
   name "Kensington TrackballWorks"
-  homepage "https://www.kensington.com/"
+  desc "Software to program Kensington Trackballs"
+  homepage "https://www.kensington.com/software/trackballworks-customization-software/"
+
+  conflicts_with cask: "homebrew/cask-drivers/kensingtonworks"
+  depends_on macos: [
+    :el_capitan,
+    :sierra,
+    :high_sierra,
+    :mojave,
+    :catalina,
+  ]
 
   pkg "Kensington TrackballWorks.pkg"
 
@@ -15,4 +25,8 @@ cask "kensington-trackball-works" do
             quit:      "com.kensington.trackballworks.helper",
             kext:      "com.kensington.trackballworks.driver",
             pkgutil:   "com.kensington.trackballworks.driver.installer"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Added `discontinued` caveat, `conflicts_with` and `depends_on` stanzas. I have also updated the homepage to the proper page.

Supported Mac OS versions reference can be found in here.
https://web.archive.org/web/20200104085024/https://www.kensington.com/software/trackballworks-customization-software/

>Mac Compatibility
Mac OS X 10.15 Catalina
Mac OS X 10.14 Mojave
Mac OS X 10.13 High Sierra
Mac OS X 10.12 Sierra
Mac OS X 10.11 El Capitan

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
