### PR TITLE
Change the cycliq-cycliqplus url path

### DIFF
--- a/Casks/cycliq-cycliqplus.rb
+++ b/Casks/cycliq-cycliqplus.rb
@@ -2,7 +2,7 @@ cask "cycliq-cycliqplus" do
   version "2.58"
   sha256 "23f1c90ccd83ff99b3269d709781e37b40778e6c87526dbb48ed4a86a875726f"
 
-  url "https://cycliq.com/files/software/CycliqPlus-#{version}.dmg"
+  url "https://cycliq.com/files/software/downloads/CycliqPlus-#{version}.dmg"
   name "CycliqPlus"
   desc "Footage and bike camera settings editor"
   homepage "https://cycliq.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

FYI: This file url was changed by distributor. FYI: #2279

```sh
curl -vvv "https://cycliq.com/software/cycliqplus/macos/"                  
*   Trying 104.26.15.180...
...
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 256)!
< HTTP/2 301 
< date: Mon, 28 Jun 2021 23:22:58 GMT
< content-type: text/html; charset=UTF-8
< set-cookie: aelia_cs_selected_currency=JPY; expires=Tue, 29-Jun-2021 23:02:46 GMT; Max-Age=86400; path=/; secure
< set-cookie: aelia_customer_country=JP; path=/; secure
< set-cookie: aelia_cs_selected_currency=JPY; expires=Tue, 29-Jun-2021 23:02:46 GMT; Max-Age=86400; path=/; secure
< cf-edge-cache: cache,platform=wordpress
< expires: Tue, 29 Jun 2021 00:02:47 GMT
< x-redirect-by: redirection
< location: /files/software/downloads/CycliqPlus-2.58.dmg
...
```