### PR TITLE
uhk-agent: update livecheck strategy to github_latest

### DIFF
--- a/Casks/uhk-agent.rb
+++ b/Casks/uhk-agent.rb
@@ -8,6 +8,12 @@ cask "uhk-agent" do
   desc "Configuration application for the Ultimate Hacking Keyboard"
   homepage "https://github.com/UltimateHackingKeyboard/agent"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/href=.*?UHK[._-]Agent[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
+  end
+
   app "UHK Agent.app"
 
   uninstall quit: "com.ultimategadgetlabs.agent"


### PR DESCRIPTION
Update livecheck to skip releases that are source only with no build.

--

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.