### PR TITLE
Add reinersct-cyberjack version SP14

### DIFF
--- a/Casks/reinersct-cyberjack.rb
+++ b/Casks/reinersct-cyberjack.rb
@@ -1,18 +1,32 @@
 cask "reinersct-cyberjack" do
-  version "3.99.5final.SP14"
-  sha256 "16c3628c7bd74617308caafc063517cfa8739d99ce0ea2159be125e1399e344c"
+  if Hardware::CPU.intel?
+    version "3.99.5final.SP13"
+    sha256 "25bcd5d5ff197163bba94e72cddb4b74ad8a04df8e88df01404378f80c46f9b4"
 
-  url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}-arm64-signed.pkg"
+    url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}-x86_64-signed.pkg"
+
+    livecheck do
+      url "https://www.reiner-sct.de/support/support-anfrage/?productGroup=77304735&product=77304820&q=driver&os=macOS"
+      regex(/href=.*?pcsc[._-]cyberjack[._-]v?(\d+(?:\.[\dA-z]+)+)[._-]x86[._-]64[._-]signed\.pkg/i)
+    end
+
+  else
+    version "3.99.5final.SP14"
+    sha256 "16c3628c7bd74617308caafc063517cfa8739d99ce0ea2159be125e1399e344c"
+
+    url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}-arm64-signed.pkg"
+
+    livecheck do
+      url "https://www.reiner-sct.de/support/support-anfrage/?productGroup=77304735&product=77304820&q=driver&os=macOS"
+      regex(/href=.*?pcsc[._-]cyberjack[._-]v?(\d+(?:\.[\dA-z]+)+)[._-]arm64[._-]signed\.pkg/i)
+    end
+  end
+
   name "reinersct-cyberjack"
   desc "Driver for smartcard readers by REINER SCT"
   homepage "https://reiner-sct.de/"
 
-  livecheck do
-    skip "No version information available"
-  end
-
-  depends_on macos: ">= :big_sur"
-  depends_on arch: :arm64
+  depends_on macos: ">= :high_sierra"
 
   pkg "pcsc-cyberjack_#{version}.pkg"
 

--- a/Casks/reinersct-cyberjack.rb
+++ b/Casks/reinersct-cyberjack.rb
@@ -1,0 +1,16 @@
+cask "reinersct-cyberjack" do
+  version "3.99.5final.SP14-arm64-signed"
+  sha256 "16c3628c7bd74617308caafc063517cfa8739d99ce0ea2159be125e1399e344c"
+
+  url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}.pkg"
+  name "reinersct-cyberjack"
+  desc "Driver for smartcard readers by REINER SCT"
+  homepage "https://reiner-sct.de/"
+
+  depends_on macos: ">= :big_sur"
+  depends_on arch: :arm64
+
+  pkg "pcsc-cyberjack_#{version}.pkg"
+
+  uninstall pkgutil: "com.reiner-sct.mac.cyberjack"
+end

--- a/Casks/reinersct-cyberjack.rb
+++ b/Casks/reinersct-cyberjack.rb
@@ -1,11 +1,15 @@
 cask "reinersct-cyberjack" do
-  version "3.99.5final.SP14-arm64-signed"
+  version "3.99.5final.SP14"
   sha256 "16c3628c7bd74617308caafc063517cfa8739d99ce0ea2159be125e1399e344c"
 
-  url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}.pkg"
+  url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}-arm64-signed.pkg"
   name "reinersct-cyberjack"
   desc "Driver for smartcard readers by REINER SCT"
   homepage "https://reiner-sct.de/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   depends_on macos: ">= :big_sur"
   depends_on arch: :arm64

--- a/Casks/reinersct-cyberjack.rb
+++ b/Casks/reinersct-cyberjack.rb
@@ -10,6 +10,7 @@ cask "reinersct-cyberjack" do
       regex(/href=.*?pcsc[._-]cyberjack[._-]v?(\d+(?:\.[\dA-z]+)+)[._-]x86[._-]64[._-]signed\.pkg/i)
     end
 
+    pkg "pcsc-cyberjack_#{version}-x86_64-signed.pkg"
   else
     version "3.99.5final.SP14"
     sha256 "16c3628c7bd74617308caafc063517cfa8739d99ce0ea2159be125e1399e344c"
@@ -20,6 +21,8 @@ cask "reinersct-cyberjack" do
       url "https://www.reiner-sct.de/support/support-anfrage/?productGroup=77304735&product=77304820&q=driver&os=macOS"
       regex(/href=.*?pcsc[._-]cyberjack[._-]v?(\d+(?:\.[\dA-z]+)+)[._-]arm64[._-]signed\.pkg/i)
     end
+
+    pkg "pcsc-cyberjack_#{version}-arm64-signed.pkg"
   end
 
   name "reinersct-cyberjack"
@@ -27,8 +30,6 @@ cask "reinersct-cyberjack" do
   homepage "https://reiner-sct.de/"
 
   depends_on macos: ">= :high_sierra"
-
-  pkg "pcsc-cyberjack_#{version}.pkg"
 
   uninstall pkgutil: "com.reiner-sct.mac.cyberjack"
 end


### PR DESCRIPTION
Driver for smart card reader manufactured by REINER SCT.
Tested with the "cyberJack komfort" reader, but other models should work too.

The latest version is supported on macOS 11 Big Sur only and requires a Mac with Apple Silicon. The previous version (SP13) also works on older macOS releases, but is built for x86_64. 

I'm not sure how to handle this situation in the cask file, if we want to support both architectures. We could ship the older version for Intel-based Macs, but if the manufacturer (already!) dropped support for x86_64, this wouldn't be a feasible solution in the long-term. I checked if the download might by wrongly labeled and could be a Universal binary:

`file libifd-cyberjack.dylib` outputs:
> libifd-cyberjack.dylib: Mach-O 64-bit dynamically linked shared library arm64

which I would interpret as being ARM-only. The driver itself is open source, so it should be possible to build an x86_64 version. I can't test it because I don't own a Intel-based Mac - I'm new to macOS entirely and switched to a MacBook Air M1 a few days ago.

If someone wants to try building from source, check the build script at https://aur.archlinux.org/packages/pcsc-cyberjack which I used on my old machine for inspiration.