### PR TITLE
Revert "Update 1kc-razer from 0.4.5 to 0.4.6"

### DIFF
--- a/Casks/1kc-razer.rb
+++ b/Casks/1kc-razer.rb
@@ -1,6 +1,6 @@
 cask "1kc-razer" do
-  version "0.4.6"
-  sha256 "0a732b770838ae59347d8b5950feec08cad2bc683936b530183a25713ae5a085"
+  version "0.4.5"
+  sha256 "5e5136c12b1138b5719a1234192c1fa7bcc85b9822bd2a9832ace73173590286"
 
   url "https://github.com/1kc/razer-macos/releases/download/v#{version}/Razer.macOS-#{version}.dmg"
   name "Razer macOS"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask-drivers#2397

@bevanjkay Looks like they [removed the download](https://github.com/1kc/razer-macos/releases)?