### PR TITLE
Add DisplayLink login extension

### DIFF
--- a/Casks/displaylink-login-extension.rb
+++ b/Casks/displaylink-login-extension.rb
@@ -1,0 +1,21 @@
+cask "displaylink-login-extension" do
+  version "2021-02"
+  sha256 "2ca0b8d0c04b7131e8877f8e5b95b177b48d1ba57aff67ccb22e28720c79c08f"
+
+  url "https://synaptics.com/sites/default/files/exe_files/#{version}/macOS%20App%20LoginExtension-EXE.dmg",
+      verified: "synaptics.com/"
+  name "DisplayLink Login Screen Extension"
+  desc "Enables DisplayLink screens prior to login"
+  homepage "https://support.displaylink.com/knowledgebase/articles/1932214-displaylink-manager-app-for-macos-introduction-in#other"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  depends_on cask: "displaylink"
+
+  pkg "DisplayLinkLoginScreenExtension.pkg"
+
+  uninstall pkgutil:   "com.displaylink.displaylinkloginscreenext",
+            launchctl: "com.displaylink.loginscreen"
+end


### PR DESCRIPTION
The included package installs a single launchctl global agent, with the plist contents listed at the end of this PR. Its sole purpose is to launch the DisplayLink driver on the login screen ([ref](https://support.displaylink.com/knowledgebase/articles/1932214-displaylink-manager-app-for-macos-introduction-in#other)).

I was torn as to whether this should be added as an extension of the main `displaylink` cask, but I decided against it since this must have been created as a separate package intentionally. Normally, it is installed via a link in the main DisplayLink Manager app which downloads the package included here.

I'm aware of the multitude of DisplayLink Manager versions provided by `displaylink`, but this extension seems to have a version which does not correspond to any of them. For that reason, I've left it as a single version. If anyone can test this on older versions of macOS (I'm on Big Sur), that would be much appreciated!

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CFBundleVersion</key>
	<string>1.4.0 (120)</string>
	<key>Disabled</key>
	<false/>
	<key>KeepAlive</key>
	<true/>
	<key>Label</key>
	<string>com.displaylink.DisplayLinkUserAgent</string>
	<key>LimitLoadToSessionType</key>
	<string>LoginWindow</string>
	<key>ProcessType</key>
	<string>Interactive</string>
	<key>ProgramArguments</key>
	<array>
		<string>/usr/bin/open</string>
		<string>-W</string>
		<string>/Applications/DisplayLink Manager.app</string>
	</array>
	<key>RunAtLoad</key>
	<true/>
	<key>ThrottleInterval</key>
	<integer>5</integer>
	<key>Umask</key>
	<integer>0</integer>
</dict>
</plist>
```
