### PR TITLE
livecheck update: graceful exit when regex fails page.match

### DIFF
--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -11,6 +11,8 @@ cask "3dconnexion" do
     url "https://3dconnexion.com/us/drivers/"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?_([\dA-F]+(?:-[\dA-F]+)*)/3DxWareMac_v(\d+(?:-\d+)*)_(r\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[3]}:#{match[1]}"
     end
   end

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -16,6 +16,8 @@ cask "insta360-studio" do
       v = macos["version"]
       regex = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
       match = macos["channels"][0]["download_url"].match(regex)
+      next if match.blank? || v.blank?
+
       "#{v},#{match[3]}:#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/insta360-studio.rb
+++ b/Casks/insta360-studio.rb
@@ -16,8 +16,6 @@ cask "insta360-studio" do
       v = macos["version"]
       regex = %r{/(\d+)/([[:xdigit:]]+)/Insta360[._-]Studio[._-](\d+(?:[._-]\d+)*)[._-]signed\.pkg}i
       match = macos["channels"][0]["download_url"].match(regex)
-      next if match.blank? || v.blank?
-
       "#{v},#{match[3]}:#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/phidget-control-panel.rb
+++ b/Casks/phidget-control-panel.rb
@@ -11,6 +11,8 @@ cask "phidget-control-panel" do
     url "https://www.phidgets.com/downloads/phidget#{version.before_comma}/libraries/macos/Phidget#{version.before_comma}.dmg"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/Phidget(\d+)_(\d+(?:\.\d+)+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -11,6 +11,8 @@ cask "synology-cloud-station-backup" do
     url "https://www.synology.com/en-us/releaseNote/CloudStationBackup"
     strategy :page_match do |page|
       match = page.match(/Version:\s*(\d+(?:\.\d+)+)-(\d+)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/toshiba-color-mfp.rb
+++ b/Casks/toshiba-color-mfp.rb
@@ -10,8 +10,10 @@ cask "toshiba-color-mfp" do
   livecheck do
     url "http://business.toshiba.com/support/downloads/GetDownloads.jsp?model=5015"
     strategy :page_match do |page|
-      version = page.match(/"MacDC",.*?"id":"(\d+)",.*?"versionName":"(\d+(?:\.\d+)+)",/)
-      "#{version[2]},#{version[1]}"
+      match = page.match(/"MacDC",.*?"id":"(\d+)",.*?"versionName":"(\d+(?:\.\d+)+)",/)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
This update causes livecheck to fail gracefully when `page.match` fails inside of the `do` block.
The documentation needs to be updated to match this pattern also.