### PR TITLE
Add macOS Big Sur version to the 3Dconnexion cask

### DIFF
--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -22,7 +22,7 @@ cask "3dconnexion" do
 
     livecheck do
       url "https://3dconnexion.com/us/support/faq/beta-driver-for-macos-11-big-sur/"
-      regex(/href=.*?3DxWareMac_(\d+(?:[.r-]\d+)*)\.dmg/i)
+      regex(/href=.*?3DxWareMac_v(\d+(?:-\d+)*_r\d+)\.dmg/i)
     end
   end
 

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -4,24 +4,31 @@ cask "3dconnexion" do
     sha256 "4752bd4297733743fb512121116b536ffe260152f97134398d028b9936bc26f9"
 
     url "https://download.3dconnexion.com/drivers/mac/#{version.before_comma}_#{version.after_colon}/3DxWareMac_v#{version.before_comma}_#{version.after_comma.before_colon}.dmg"
+
+    livecheck do
+      url "https://3dconnexion.com/us/drivers/"
+      strategy :page_match do |page|
+        match = page.match(%r{href=.*?_([\dA-F]+(?:-[\dA-F]+)*)/3DxWareMac_v(\d+(?:-\d+)*)_(r\d+)\.dmg}i)
+        next if match.blank?
+
+        "#{match[2]},#{match[3]}:#{match[1]}"
+      end
+    end
   else
     version "10-7-0_r3386"
     sha256 "bebd9c01c96bfb9411fd5b4ccd2bbba3b798cba001b0e200547d0e9c3dcbf893"
 
     url "https://download.3dconnexion.com/drivers/technical_support/3DxWareMac_v#{version}.dmg"
+
+    livecheck do
+      url "https://3dconnexion.com/us/support/faq/beta-driver-for-macos-11-big-sur/"
+      regex(/href=.*?3DxWareMac_(\d+(?:[.r-]\d+)*)\.dmg/i)
+    end
   end
 
   name "3Dconnexion"
   desc "3DxWare Driver"
   homepage "https://3dconnexion.com/"
-
-  livecheck do
-    url "https://3dconnexion.com/us/drivers/"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?_([\dA-F]+(?:-[\dA-F]+)*)/3DxWareMac_v(\d+(?:-\d+)*)_(r\d+)\.dmg}i)
-      "#{match[2]},#{match[3]}:#{match[1]}"
-    end
-  end
 
   depends_on macos: ">= :yosemite"
 

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -1,8 +1,16 @@
 cask "3dconnexion" do
-  version "10-6-7,r3287:36E24890-6B5F-443a-8A9F-1851F9ADB985"
-  sha256 "4752bd4297733743fb512121116b536ffe260152f97134398d028b9936bc26f9"
+  if MacOS.version <= :yosemite && MacOS.version <= :el_capitan && MacOS.version <= :sierra && MacOS.version <= :high_sierra && MacOS.version <= :mojave && MacOS.version <= :catalina
+    version "10-6-7,r3287:36E24890-6B5F-443a-8A9F-1851F9ADB985"
+    sha256 "4752bd4297733743fb512121116b536ffe260152f97134398d028b9936bc26f9"
 
-  url "https://download.3dconnexion.com/drivers/mac/#{version.before_comma}_#{version.after_colon}/3DxWareMac_v#{version.before_comma}_#{version.after_comma.before_colon}.dmg"
+    url "https://download.3dconnexion.com/drivers/mac/#{version.before_comma}_#{version.after_colon}/3DxWareMac_v#{version.before_comma}_#{version.after_comma.before_colon}.dmg"
+  else
+    version "10-7-0_r3386"
+    sha256 "bebd9c01c96bfb9411fd5b4ccd2bbba3b798cba001b0e200547d0e9c3dcbf893"
+
+    url "https://download.3dconnexion.com/drivers/technical_support/3DxWareMac_v#{version}.dmg"
+  end
+
   name "3Dconnexion"
   desc "3DxWare Driver"
   homepage "https://3dconnexion.com/"

--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -1,5 +1,5 @@
 cask "3dconnexion" do
-  if MacOS.version <= :yosemite && MacOS.version <= :el_capitan && MacOS.version <= :sierra && MacOS.version <= :high_sierra && MacOS.version <= :mojave && MacOS.version <= :catalina
+  if MacOS.version <= :catalina
     version "10-6-7,r3287:36E24890-6B5F-443a-8A9F-1851F9ADB985"
     sha256 "4752bd4297733743fb512121116b536ffe260152f97134398d028b9936bc26f9"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

**Note:** The command `brew style --fix 3dconnexion` reports the following offense: `2:119: C: Line is too long. [182/118]`. Unfortunately I've no idea how to fix this offense. Hopefully a more experienced contributor has a solution.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
