### PR TITLE
Update Logitech Control Center download URL

### DIFF
--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -2,7 +2,7 @@ cask "logitech-control-center" do
   version "3.9.14"
   sha256 "41839c121b0df080329de1879ce52a1130cd8fe265b602ca877fe383d8cfd0fe"
 
-  url "https://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
+  url "https://download01.logi.com/web/ftp/pub/techsupport/mouse/mac/lcc#{version}.zip"
   name "Logitech Control Center"
   desc "Customize your mouse and keyboard"
   homepage "https://support.logitech.com/en_us/product/3129"

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -2,7 +2,8 @@ cask "logitech-control-center" do
   version "3.9.14"
   sha256 "41839c121b0df080329de1879ce52a1130cd8fe265b602ca877fe383d8cfd0fe"
 
-  url "https://download01.logi.com/web/ftp/pub/techsupport/mouse/mac/lcc#{version}.zip"
+  url "https://download01.logi.com/web/ftp/pub/techsupport/mouse/mac/lcc#{version}.zip",
+      verified: "download01.logi.com/web/ftp/pub/techsupport/"
   name "Logitech Control Center"
   desc "Customize your mouse and keyboard"
   homepage "https://support.logitech.com/en_us/product/3129"


### PR DESCRIPTION
Logitech apparently changed CDN. Same goes for [Logitech Options](https://github.com/Homebrew/homebrew-cask-drivers/blob/master/Casks/logitech-options.rb).

After making all changes to a cask, verify:

- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.