### PR TITLE
fujitsu-scansnap-home 2.3.0

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,6 +1,6 @@
 cask "fujitsu-scansnap-home" do
-  version "2.1.0"
-  sha256 "3b293ca40d38910393153f26705499c2b966dbaaeed252d15625b582311fb332"
+  version "2.3.0"
+  sha256 "64e27b60245da21a20aa92bf62a1291048947502851bf4839635f6fcd8e80b90"
 
   url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg",
       verified: "origin.pfultd.com/"
@@ -8,9 +8,11 @@ cask "fujitsu-scansnap-home" do
   desc "Fujitsu ScanSnap Scanner software"
   homepage "https://www.fujitsu.com/global/products/computing/peripheral/scanners/soho/sshome/"
 
+  # Some of the release titles contain a typo where a space is omitted, so this
+  # regex is a bit extreme about whitespace to ensure we match all the versions.
   livecheck do
     url "https://www.pfu.fujitsu.com/imaging/ss_hist/en/mac/index.html"
-    regex(/ScanSnap Home for Mac (\d+(?:\.\d+)+) Released/i)
+    regex(/ScanSnap\s*Home\s*for\s*Mac\s*v?(\d+(?:\.\d+)+)\s*Released/i)
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `fujitsu-scansnap-home` to the latest version, `2.3.0`.

Additionally, this updates the existing `livecheck` block regex to be a bit looser about the whitespace between words. The upstream "Update History" page currently contains typos in matched release title text where an expected space is missing (e.g., `ScanSnap Homefor Mac 2.3.0 Released` instead of the usual `ScanSnap Home for Mac 2.1.0 Released` format). The missing space in the latest release titles was causing the regex not to match them and `2.1.0` was erroneously reported as newest instead of `2.3.0` (as the `2.2.10` and `2.3.0` releases both have typos in the title).

The approach in the updated regex is perhaps a bit overkill and it's not something we normally have to do in most `livecheck` block regexes but I think it makes sense here and I've explained the relative absurdity in the preceding comment.