### PR TITLE
Update konica-minolta-bizhub-c750i-driver from 2.2.3 to 3.0.1

### DIFF
--- a/Casks/konica-minolta-bizhub-c750i-driver.rb
+++ b/Casks/konica-minolta-bizhub-c750i-driver.rb
@@ -1,7 +1,7 @@
 cask "konica-minolta-bizhub-c750i-driver" do
   if MacOS.version <= :catalina
-    version "2.2.3,7e6620c13efd50326af685f926806e0f,125070"
-    sha256 "dca184d4122ef1a3af821f64731110d632be813fd2df1e875dd170dad89188b0"
+    version "3.0.1,6454ed166639340e7f81bda0dcaeb554,129004"
+    sha256 "4aebd127a1ca363611e04ebb5666efdaf3de2dff1e933bb7ac82f832de878f94"
 
     pkg "A4/C750i_C650i_C360i_C287i_C286i_C4050i_C4000i_C3320i.pkg"
   else

--- a/Casks/konica-minolta-bizhub-c750i-driver.rb
+++ b/Casks/konica-minolta-bizhub-c750i-driver.rb
@@ -1,17 +1,17 @@
 cask "konica-minolta-bizhub-c750i-driver" do
   if MacOS.version <= :catalina
-    version "2.2.3,7e6620c13efd50326af685f926806e0f:125070"
+    version "2.2.3,7e6620c13efd50326af685f926806e0f,125070"
     sha256 "dca184d4122ef1a3af821f64731110d632be813fd2df1e875dd170dad89188b0"
 
     pkg "A4/C750i_C650i_C360i_C287i_C286i_C4050i_C4000i_C3320i.pkg"
   else
-    version "2.2.3A,d87425ee468e6d834887936aca5b096c:127009"
+    version "2.2.3A,d87425ee468e6d834887936aca5b096c,127009"
     sha256 "f200cbfa7322c45b864144388bf86d29f94fbf7f6e4c110ff61bedd3b62043f4"
 
     pkg "C750i_C650i_C360i_C287i_C286i_C4050i_C4000i_C3320i_11.pkg"
   end
 
-  url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=#{version.after_comma.before_colon}&tx_kmanacondaimport_downloadproxy[documentId]=#{version.after_colon}&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
+  url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=#{version.csv[1]}&tx_kmanacondaimport_downloadproxy[documentId]=#{version.csv[2]}&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
   name "Konica Minolta Bizhub C750i/C650i/C360i/C287i/C286i/C4050i/C4000i/C3320i Printer Driver"
   desc "PostScript printer driver"
   homepage "https://www.konicaminolta.eu/eu-en/support/download-centre"
@@ -28,7 +28,7 @@ cask "konica-minolta-bizhub-c750i-driver" do
       files = item["DownloadFiles_textS"].split("\n").map { |file| file.split("|") }
       dmg = files.find { |f| f.first.end_with?(".dmg") }
 
-      "#{item["Version_textS"]},#{Digest::MD5.hexdigest(dmg[2])}:#{item["AnacondaId_textS"]}"
+      "#{item["Version_textS"]},#{Digest::MD5.hexdigest(dmg[2])},#{item["AnacondaId_textS"]}"
     end
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

https://github.com/Homebrew/homebrew-cask/issues/95207