### PR TITLE
steelseries-gg: Mark as incompatible with M1

### DIFF
--- a/Casks/steelseries-gg.rb
+++ b/Casks/steelseries-gg.rb
@@ -16,6 +16,7 @@ cask "steelseries-gg" do
   auto_updates true
   conflicts_with cask: "steelseries-engine"
   depends_on macos: ">= :sierra"
+  depends_on arch: :x86_64
 
   pkg "SteelSeriesGG#{version}.pkg"
 


### PR DESCRIPTION
The current version of `steelseries-gg` is not compatible with M1 because the builtin kernel extension does not load on M1.

```
Executing: /usr/bin/kmutil load -p /Library/Extensions/SteelSeriesEngine3Driver.kext
Error Domain=KMErrorDomain Code=71 "Incompatible architecture: Binary is for x86_64, but needed arch arm64e
Unsupported Error: one or more extensions are unsupported to load       Kext com.steelseries.ssenext.driver v1.6.23 in executable kext bundle com.steelseries.ssenext.driver at /Library/Extensions/SteelSeriesEngine3Driver.kext
Unsupported Error: one or more extensions are unsupported to load       Kext com.steelseries.ssenext.driver v1.6.23 in executable kext bundle com.steelseries.ssenext.driver at /Library/Extensions/SteelSeriesEngine3Driver.kext" UserInfo={NSLocalizedDescription=Incompatible architecture: Binary is for x86_64, but needed arch arm64e
Unsupported Error: one or more extensions are unsupported to load       Kext com.steelseries.ssenext.driver v1.6.23 in executable kext bundle com.steelseries.ssenext.driver at /Library/Extensions/SteelSeriesEngine3Driver.kext
Unsupported Error: one or more extensions are unsupported to load       Kext com.steelseries.ssenext.driver v1.6.23 in executable kext bundle com.steelseries.ssenext.driver at /Library/Extensions/SteelSeriesEngine3Driver.kext}
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
