### PR TITLE
Add cameracontroller 1.3.1

### DIFF
--- a/Casks/cameracontroller.rb
+++ b/Casks/cameracontroller.rb
@@ -1,0 +1,26 @@
+cask "cameracontroller" do
+  version "1.3.1"
+  sha256 "f17e1327ed48db62c9532cdc4e42aba68a539d81d2f7fc44daeea140c3f402d3"
+
+  url "https://github.com/Itaybre/CameraController/releases/download/#{version}/CameraController.zip"
+  name "CameraController"
+  desc "Control USB Cameras from an app"
+  homepage "https://github.com/Itaybre/CameraController"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "CameraController.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.itaysoft.CameraController",
+    "~/Library/Application Scripts/com.itaysoft.CameraController.Helper",
+    "~/Library/Application Support/CameraController",
+    "~/Library/Containers/CameraController",
+    "~/Library/Preferences/com.itaysoft.CameraController.plist",
+  ]
+end

--- a/Casks/cameracontroller.rb
+++ b/Casks/cameracontroller.rb
@@ -5,12 +5,7 @@ cask "cameracontroller" do
   url "https://github.com/Itaybre/CameraController/releases/download/#{version}/CameraController.zip"
   name "CameraController"
   desc "Control USB Cameras from an app"
-  homepage "https://github.com/Itaybre/CameraController"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  homepage "https://github.com/Itaybre/CameraController/"
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
CameraController app allows to adjust UVC web-camera settings even if vendor software is not provided.

Homepage: https://github.com/Itaybre/CameraController

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask cameracontroller` is error-free.
- [x] `brew style --fix cameracontroller` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask cameracontroller` worked successfully.
- [x] `brew install --cask cameracontroller` worked successfully.
- [x] `brew uninstall --cask cameracontroller` worked successfully.
