### PR TITLE
roland-quad-capture-usb-driver: fix deprecation.

### DIFF
--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -72,7 +72,7 @@ cask "roland-quad-capture-usb-driver" do
   ]
 
   caveats do
-    license "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/#{version.csv.third}"
+    license "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers"
     reboot
   end
 end

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -72,7 +72,7 @@ cask "roland-quad-capture-usb-driver" do
   ]
 
   caveats do
-    license "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/#{version.after_colon}"
+    license "https://www.roland.com/us/support/by_product/quad-capture/updates_drivers/#{version.csv.third}"
     reboot
   end
 end


### PR DESCRIPTION
Fix `Cask::DSL::Version#after_colon` deprecation: 
https://github.com/Homebrew/brew/runs/5285711256?check_suite_focus=true#step:10:8

Blocking https://github.com/Homebrew/brew/pull/12913