### PR TITLE
Update muteme cask to support Apple Silicon

### DIFF
--- a/Casks/muteme.rb
+++ b/Casks/muteme.rb
@@ -10,8 +10,8 @@ cask "muteme" do
   end
 
   url "https://muteme.io/download/flavor/default/#{version}/#{arch}/MuteMe-Client-#{version}.dmg",
-      verified: "https://muteme.io/"
-  name "muteme"
+      verified: "muteme.io/download/flavor/default/"
+  name "MuteMe"
   desc "Companion app for the MuteMe physical mute button"
   homepage "https://muteme.com/"
 

--- a/Casks/muteme.rb
+++ b/Casks/muteme.rb
@@ -1,15 +1,22 @@
 cask "muteme" do
-  version "0.8.3"
-  sha256 "a40ece78cf534775b9bc3e9b4211d7ab8c1af053c01e145dbefd5cfe4205b27d"
+  arch = Hardware::CPU.intel? ? "osx_64" : "osx_arm4"
 
-  url "https://muteme.io/download/flavor/default/#{version}/osx_64/MuteMe-Client-#{version}.dmg",
+  version "0.9.2"
+
+  if Hardware::CPU.intel?
+    sha256 "788efd319495b9b221c5a4706d2e63c6147d807c168ec2ae7a39d9ac6d521c5d"
+  else
+    sha256 "9bc1225d65931c189ad953c90c8e67299d9d7336728312754bc430607dab7397"
+  end
+
+  url "https://muteme.io/download/flavor/default/#{version}/#{arch}/MuteMe-Client-#{version}.dmg",
       verified: "https://muteme.io/"
   name "muteme"
   desc "Companion app for the MuteMe physical mute button"
   homepage "https://muteme.com/"
 
   livecheck do
-    url "https://downloads.muteme.com/download/latest/osx_64"
+    url "https://downloads.muteme.com/download/latest/#{arch}"
     strategy :header_match
   end
 

--- a/Casks/muteme.rb
+++ b/Casks/muteme.rb
@@ -1,5 +1,5 @@
 cask "muteme" do
-  arch = Hardware::CPU.intel? ? "osx_64" : "osx_arm4"
+  arch = Hardware::CPU.intel? ? "osx_64" : "osx_arm64"
 
   version "0.9.2"
 


### PR DESCRIPTION
Muteme at some point has added separate downloads for Intel and Apple CPUs. This PR is to download and install the correct one.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
