### PR TITLE
xppen-pentablet 3.2.3_211203. Version rollback and fix.

### DIFF
--- a/Casks/xppen-pentablet.rb
+++ b/Casks/xppen-pentablet.rb
@@ -1,5 +1,5 @@
 cask "xppen-pentablet" do
-  version "3.3.0_220110"
+  version "3.2.3_211203"
   sha256 :no_check
 
   url "https://www.xp-pen.com/download/file/id/1968"
@@ -15,7 +15,7 @@ cask "xppen-pentablet" do
 
   container nested: "XP-PENMac_#{version}/XP-PENMac_#{version}.dmg"
 
-  app "XP-PenPenTabletPro/PenTablet.app"
+  suite "XP-PenPenTabletPro"
 
   zap trash: [
     "/Library/Application Support/PenDriver",


### PR DESCRIPTION
The previous version of this cask pointed to a non-existent future version. The URL pointed to the correct (latest) version. As a result, Homebrew was able to download the .dmg file, but it couldn't install it.

This change also fixes the installation of drivers. The suite's  directory contains a hidden subdirectory with supporting files (drivers). If the .app is copied in isolation, it is unable to install drivers upon first start.

Confirmed working by testing in a fresh MacOS installation.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
