### PR TITLE
Adds support for MacOS Monterey

### DIFF
--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -27,6 +27,7 @@ cask "safenet-authentication-client" do
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"
 
+  # required due to the processes not having a bundle_id
   uninstall_postflight do
     system "killall", "SACMonitor"
     system "killall", "SACTools"

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -31,10 +31,8 @@ cask "safenet-authentication-client" do
     "com.SafeNet.SACMonitor",
     "com.SafeNet.SACSrv",
   ],
-            signal:    ["QUIT", "com.SafeNet.SACMonitor"],
             quit:	     [
               "com.gemalto.Gemalto-Smart-Card-Token.PKCS11-Token",
-              "com.SafeNet.SACMonitor",
             ],
             pkgutil:   [
               "com.safenet.safenetAuthenticationClient.eTokenConf.pkg",

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -22,6 +22,7 @@ cask "safenet-authentication-client" do
   depends_on macos: [
     :catalina,
     :big_sur,
+    :monterey,
   ]
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"
@@ -33,6 +34,7 @@ cask "safenet-authentication-client" do
             signal:    ["QUIT", "com.SafeNet.SACMonitor"],
             quit:	     [
               "com.gemalto.Gemalto-Smart-Card-Token.PKCS11-Token",
+              "SACMonitor",
             ],
             pkgutil:   [
               "com.safenet.safenetAuthenticationClient.eTokenConf.pkg",

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -20,9 +20,9 @@ cask "safenet-authentication-client" do
   end
 
   depends_on macos: [
-     :catalina,
-     :big_sur,
-   ]
+    :catalina,
+    :big_sur,
+  ]
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"
 

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -19,11 +19,7 @@ cask "safenet-authentication-client" do
     skip "No version information available"
   end
 
-  depends_on macos: [
-    :catalina,
-    :big_sur,
-    :monterey,
-  ]
+  depends_on macos: ">= :catalina"
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"
 

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -27,6 +27,11 @@ cask "safenet-authentication-client" do
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"
 
+  uninstall_postflight do
+    system "killall", "SACMonitor"
+    system "killall", "SACTools"
+  end
+
   uninstall	launchctl: [
     "com.SafeNet.SACMonitor",
     "com.SafeNet.SACSrv",
@@ -34,7 +39,6 @@ cask "safenet-authentication-client" do
             signal:    ["QUIT", "com.SafeNet.SACMonitor"],
             quit:	     [
               "com.gemalto.Gemalto-Smart-Card-Token.PKCS11-Token",
-              "SACMonitor",
             ],
             pkgutil:   [
               "com.safenet.safenetAuthenticationClient.eTokenConf.pkg",

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -6,7 +6,7 @@ cask "safenet-authentication-client" do
     container nested: "Safenet #{version.major_minor} Post GA R3/Safenet #{version.major_minor} Post GA R3/SafeNetAuthenticationClient.#{version}.dmg"
   else
     version "10.2.111.0"
-    sha256 "af622151e7188d25f326420d3d210dc676002c765a670bd756fd40bd050fd0a5"
+    sha256 "a4055ed4d6584e400d86c57b744b42aa7f908b3939d7223487bfe20b2a519a86"
     url "https://www.globalsign.com/en/safenet-drivers/USB/#{version.major_minor}/Safenet_#{version.major_minor}_Post_GA_(R4).zip"
     container nested: "Safenet #{version.major_minor} Post GA (R4) 2/SafeNet Authentication Client #{version.major_minor}.pkg"
   end
@@ -22,6 +22,7 @@ cask "safenet-authentication-client" do
   depends_on macos: [
     :catalina,
     :big_sur,
+    :monterey,
   ]
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -19,7 +19,10 @@ cask "safenet-authentication-client" do
     skip "No version information available"
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: [
+     :catalina,
+     :big_sur,
+   ]
 
   pkg "SafeNet Authentication Client #{version.major_minor}.pkg"
 

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -34,6 +34,7 @@ cask "safenet-authentication-client" do
             signal:    ["QUIT", "com.SafeNet.SACMonitor"],
             quit:	     [
               "com.gemalto.Gemalto-Smart-Card-Token.PKCS11-Token",
+              "com.SafeNet.SACMonitor",
             ],
             pkgutil:   [
               "com.safenet.safenetAuthenticationClient.eTokenConf.pkg",

--- a/Casks/safenet-authentication-client.rb
+++ b/Casks/safenet-authentication-client.rb
@@ -30,6 +30,7 @@ cask "safenet-authentication-client" do
     "com.SafeNet.SACMonitor",
     "com.SafeNet.SACSrv",
   ],
+            signal:    ["QUIT", "com.SafeNet.SACMonitor"],
             quit:	     [
               "com.gemalto.Gemalto-Smart-Card-Token.PKCS11-Token",
             ],


### PR DESCRIPTION
SafeNet Authentication Client does not indicate support for Monterey on their site, but they have uploaded a new package that does appear to support Monterey.

- Update `sha256` to reflect new package
- Add dependency for `:monterey`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Supplementary material:

```
% brew audit --cask safenet-authentication-client
audit for safenet-authentication-client: passed
```

```
% brew style --fix safenet-authentication-client

1 file inspected, no offenses detected
```