### PR TITLE
Remove unnecessary strategy calls

### DIFF
--- a/Casks/audient-evo.rb
+++ b/Casks/audient-evo.rb
@@ -10,7 +10,6 @@ cask "audient-evo" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/EVO%20v(\d+(?:\.\d+)*(?:rc\d+)?)\.dmg}i)
   end
 

--- a/Casks/blue-sherpa.rb
+++ b/Casks/blue-sherpa.rb
@@ -9,7 +9,6 @@ cask "blue-sherpa" do
 
   livecheck do
     url "https://software.bluemic.com/blue/"
-    strategy :page_match
     regex(/href=.*?BlueSherpa-(\d+)\.pkg/i)
   end
 

--- a/Casks/bose-updater.rb
+++ b/Casks/bose-updater.rb
@@ -9,7 +9,6 @@ cask "bose-updater" do
 
   livecheck do
     url "https://btu.bose.com/data/MUV.xml"
-    strategy :page_match
     regex(/ROOT\sMUV="(\d+(?:.\d+)*)"/i)
   end
 

--- a/Casks/bragi-updater.rb
+++ b/Casks/bragi-updater.rb
@@ -9,7 +9,6 @@ cask "bragi-updater" do
 
   livecheck do
     url "https://update.bragi.com/scripts/scripts.36513c90.js"
-    strategy :page_match
     regex(%r{href="/bin/Bragi\s*Updater-(\d+(?:\.\d+)+)\.dmg"}i)
   end
 

--- a/Casks/clavia-nord-sound-manager.rb
+++ b/Casks/clavia-nord-sound-manager.rb
@@ -9,7 +9,6 @@ cask "clavia-nord-sound-manager" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/Nord%20Sound%20Manager%20v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -14,7 +14,6 @@ cask "concept2-utility" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Concept2\s+Utility\s+(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -9,7 +9,6 @@ cask "evolv-escribe-suite" do
 
   livecheck do
     url "https://www.evolvapor.com/escribe"
-    strategy :page_match
     regex(%r{href=.*?/SetupEScribe(\d+_SP\d+(?:_\d+)?)_INT\.pkg}i)
   end
 

--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -9,7 +9,6 @@ cask "focusrite-control" do
 
   livecheck do
     url "https://customer.focusrite.com/en/support/downloads?brand=Focusrite&product_by_type=1501&download_type=software"
-    strategy :page_match
     regex(%r{href=.*?/Focusrite%20Control%20-%20(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/fractal-bot.rb
+++ b/Casks/fractal-bot.rb
@@ -9,7 +9,6 @@ cask "fractal-bot" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Version\s*(\d+(?:\.\d+)+).*?\.dmg/i)
   end
 

--- a/Casks/gopro-webcam.rb
+++ b/Casks/gopro-webcam.rb
@@ -9,7 +9,6 @@ cask "gopro-webcam" do
 
   livecheck do
     url "https://community.gopro.com/t5/en/How-To-Use-Your-GoPro-As-A-Webcam/ta-p/665493#releasenotes"
-    strategy :page_match
     regex(%r{Mac\s*Webcam\s*</B><BR\s/>Version\s*(\d+(?:\.\d+)+)}i)
   end
 

--- a/Casks/hhkb-pro-driver.rb
+++ b/Casks/hhkb-pro-driver.rb
@@ -9,7 +9,6 @@ cask "hhkb-pro-driver" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/HHKBProDriver(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/huiontablet.rb
+++ b/Casks/huiontablet.rb
@@ -9,7 +9,6 @@ cask "huiontablet" do
 
   livecheck do
     url "https://huion.com/download/"
-    strategy :page_match
     regex(%r{Mac/HuionTablet_MacDriver_v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/lacie-network-assistant.rb
+++ b/Casks/lacie-network-assistant.rb
@@ -9,7 +9,6 @@ cask "lacie-network-assistant" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/LaCie Network Assistant-(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -14,7 +14,6 @@ cask "logitech-unifying" do
 
   livecheck do
     url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=ec9eb8f1-8e0b-11e9-a62b-5b664cf4d3da"
-    strategy :page_match
     regex(/unifying(\d+(?:\.\d+)+)_mac\.zip/i)
   end
 

--- a/Casks/picoscope.rb
+++ b/Casks/picoscope.rb
@@ -9,7 +9,6 @@ cask "picoscope" do
 
   livecheck do
     url "https://www.picotech.com/downloads/_lightbox/"
-    strategy :page_match
     regex(%r{href=.*?/PicoScope-(\d+(?:.\d+)*)\.pkg}i)
   end
 

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -9,7 +9,6 @@ cask "prolific-pl2303" do
 
   livecheck do
     url "http://www.prolific.com.tw/US/ShowProduct.aspx?p_id=229&pcid=41"
-    strategy :page_match
     regex(/PL2303HXD_G_Mac\s*Driver_v?(\d+(?:\.\d+)*_\d+)\.zip/i)
   end
 

--- a/Casks/qnap-external-raid-manager.rb
+++ b/Casks/qnap-external-raid-manager.rb
@@ -9,7 +9,6 @@ cask "qnap-external-raid-manager" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/QNAPExternalRAIDManagerMac-(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/rapoo-mt750s.rb
+++ b/Casks/rapoo-mt750s.rb
@@ -10,7 +10,6 @@ cask "rapoo-mt750s" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/RapooOptions_MT750S_(\d+)\.pkg/i)
   end
 

--- a/Casks/segger-ozone.rb
+++ b/Casks/segger-ozone.rb
@@ -9,7 +9,6 @@ cask "segger-ozone" do
 
   livecheck do
     url "https://www.segger.com/downloads/jlink/ReleaseNotes_Ozone.html"
-    strategy :page_match
     regex(/<h2>Version\s*(\d+(?:\.\d+)*[a-z]?)/i)
   end
 

--- a/Casks/sony-rcs300.rb
+++ b/Casks/sony-rcs300.rb
@@ -16,7 +16,6 @@ cask "sony-rcs300" do
 
   livecheck do
     url "https://www.sony.co.jp/Products/felica/consumer/support/download/usbdriver.html"
-    strategy :page_match
     regex(%r{href=.*?/usbdriver#{arch}[._-]s300[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/tomtom-mydrive-connect.rb
+++ b/Casks/tomtom-mydrive-connect.rb
@@ -9,7 +9,6 @@ cask "tomtom-mydrive-connect" do
 
   livecheck do
     url "https://help.tomtom.com/hc/en-us/articles/360014400719-MyDrive-Connect"
-    strategy :page_match
     regex(/Version:\s*(\d+(?:\.\d+)+)\s*OS:\s*mac/i)
   end
 

--- a/Casks/yamaha-usb-midi-driver.rb
+++ b/Casks/yamaha-usb-midi-driver.rb
@@ -9,7 +9,6 @@ cask "yamaha-usb-midi-driver" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/USB-MIDI\sDriver\sV?(\d+(?:\.\d+)+)\sfor\sMac/i)
   end
 

--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -9,7 +9,6 @@ cask "yubico-authenticator" do
 
   livecheck do
     url "https://developers.yubico.com/yubioath-desktop/Releases/"
-    strategy :page_match
     regex(/href=.*?yubioath-desktop-(\d+(\.\d+)*[a-z]?)-mac\.pkg/i)
   end
 

--- a/Casks/yubico-yubikey-piv-manager.rb
+++ b/Casks/yubico-yubikey-piv-manager.rb
@@ -9,7 +9,6 @@ cask "yubico-yubikey-piv-manager" do
 
   livecheck do
     url "https://developers.yubico.com/yubikey-piv-manager/Releases/"
-    strategy :page_match
     regex(/href=.*?yubikey-piv-manager-(\d+(?:\.\d+)*[a-z]?)-mac\.pkg/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


---

The `#strategy` calls in the `livecheck` blocks in this PR are redundant, as the specified strategy is the same as the default strategy for the `livecheck` block URL. This PR removes these `#strategy` calls, as we only use `#strategy` to override the default strategy or when a `strategy` block is used.

To be clear, the verbose JSON output from `brew livecheck` is unchanged after these `#strategy` call removals, confirming that they were unnecessary.