### PR TITLE
Pass regex into strategy block, use #scan

### DIFF
--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -7,11 +7,9 @@ cask "3dconnexion" do
 
     livecheck do
       url "https://3dconnexion.com/us/drivers/"
-      strategy :page_match do |page|
-        match = page.match(%r{href=.*?_([\dA-F]+(?:-[\dA-F]+)*)/3DxWareMac_v(\d+(?:-\d+)*)_(r\d+)\.dmg}i)
-        next if match.blank?
-
-        "#{match[2]},#{match[3]},#{match[1]}"
+      regex(%r{href=.*?_([\dA-F]+(?:-[\dA-F]+)*)/3DxWareMac_v(\d+(?:-\d+)*)_(r\d+)\.dmg}i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| "#{match[1]},#{match[2]},#{match[0]}" }
       end
     end
   else

--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -7,13 +7,11 @@ cask "asix-ax88179" do
 
     livecheck do
       url "https://www.asix.com.tw/en/support/download/step2/11/2/3"
-      strategy :page_match do |page|
+      regex(%r{data-href=.*?/download/file/(\d+).*?macOS\s*10.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi)
+      strategy :page_match do |page, regex|
         page.split(/class=['"]?list__item['"]?/).map do |list_item|
-          match = list_item.match(
-            %r{data-href=.*?/download/file/(\d+).*?macOS\s*10.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi,
-          )
-          "#{match[2]},#{match[1]}" if match
-        end.compact
+          list_item.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+        end.flatten
       end
     end
   elsif MacOS.version <= :catalina
@@ -24,13 +22,11 @@ cask "asix-ax88179" do
 
     livecheck do
       url "https://www.asix.com.tw/en/support/download/step2/11/2/3"
-      strategy :page_match do |page|
+      regex(%r{data-href=.*?/download/file/(\d+).*?macOS\s*10.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi)
+      strategy :page_match do |page, regex|
         page.split(/class=['"]?list__item['"]?/).map do |list_item|
-          match = list_item.match(
-            %r{data-href=.*?/download/file/(\d+).*?macOS\s*10.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi,
-          )
-          "#{match[2]},#{match[1]}" if match
-        end.compact
+          list_item.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+        end.flatten
       end
     end
   elsif MacOS.version <= :big_sur
@@ -41,13 +37,11 @@ cask "asix-ax88179" do
 
     livecheck do
       url "https://www.asix.com.tw/en/support/download/step2/11/2/3"
-      strategy :page_match do |page|
+      regex(%r{data-href=.*?/download/file/(\d+).*?macOS\s*11.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi)
+      strategy :page_match do |page, regex|
         page.split(/class=['"]?list__item['"]?/).map do |list_item|
-          match = list_item.match(
-            %r{data-href=.*?/download/file/(\d+).*?macOS\s*11.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi,
-          )
-          "#{match[2]},#{match[1]}" if match
-        end.compact
+          list_item.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+        end.flatten
       end
     end
   else
@@ -58,13 +52,11 @@ cask "asix-ax88179" do
 
     livecheck do
       url "https://www.asix.com.tw/en/support/download/step2/11/2/3"
-      strategy :page_match do |page|
+      regex(%r{data-href=.*?/download/file/(\d+).*?macOS\s*12.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi)
+      strategy :page_match do |page, regex|
         page.split(/class=['"]?list__item['"]?/).map do |list_item|
-          match = list_item.match(
-            %r{data-href=.*?/download/file/(\d+).*?macOS\s*12.*?Vision\s*?(?:<br>)?\s*?(\d+(?:\.\d+)+)<}mi,
-          )
-          "#{match[2]},#{match[1]}" if match
-        end.compact
+          list_item.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+        end.flatten
       end
     end
   end

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -10,10 +10,9 @@ cask "elektron-overbridge" do
 
   livecheck do
     url "https://www.elektron.se/support/?connection=overbridge"
-    strategy :page_match do |page|
-      page.scan(%r{href=.*?/(\h+(?:-\h+)*)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i).map do |match|
-        "#{match[1]},#{match[0]}"
-      end
+    regex(%r{href=.*?/(\h+(?:-\h+)*)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/elektron-transfer.rb
+++ b/Casks/elektron-transfer.rb
@@ -10,10 +10,9 @@ cask "elektron-transfer" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      page.scan(%r{href=.*?/(\h+(?:-\h+)*)/Elektron[._-]?Transfer[._-]?v?(\d+(?:\.\d+)+)\.dmg}i).map do |match|
-        "#{match[1]},#{match[0]}"
-      end
+    regex(%r{href=.*?/(\h+(?:-\h+)*)/Elektron[._-]?Transfer[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/fujifilm-x-raw-studio.rb
+++ b/Casks/fujifilm-x-raw-studio.rb
@@ -9,11 +9,9 @@ cask "fujifilm-x-raw-studio" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      match = page.match(%r{x[._-]raw[._-]studio[._-]macv?(\d*)[._-](.*)/XRawStudio(\d*)\.dmg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{x[._-]raw[._-]studio[._-]macv?(\d*)[._-](.*)/XRawStudio(\d*)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/nordic-nrf-command-line-tools.rb
+++ b/Casks/nordic-nrf-command-line-tools.rb
@@ -9,9 +9,9 @@ cask "nordic-nrf-command-line-tools" do
 
   livecheck do
     url "https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download"
-    strategy :page_match do |page|
-      page.scan(/nRF[._-]Command[._-]Line[._-]Tools[._-]v?(\d+(?:[_.]\d+)+)[._-]OSX\.zip/i)
-          .map { |match| match[0].tr("_", ".") }
+    regex(/nRF[._-]Command[._-]Line[._-]Tools[._-]v?(\d+(?:[._]\d+)+)[._-]OSX\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/phidget-control-panel.rb
+++ b/Casks/phidget-control-panel.rb
@@ -9,8 +9,9 @@ cask "phidget-control-panel" do
 
   livecheck do
     url "https://www.phidgets.com/downloads/phidget#{version.csv.first}/libraries/macos/Phidget#{version.csv.first}.dmg"
-    strategy :header_match do |headers|
-      match = headers["location"].match(%r{/Phidget(\d+)_(\d+(?:\.\d+)+)\.dmg}i)
+    regex(%r{/Phidget(\d+)_(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"].match(regex)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"

--- a/Casks/ricoh-ps-printers-vol3-exp-driver.rb
+++ b/Casks/ricoh-ps-printers-vol3-exp-driver.rb
@@ -9,10 +9,9 @@ cask "ricoh-ps-printers-vol3-exp-driver" do
 
   livecheck do
     url "https://support.ricoh.com/bb/html/dr_ut_e/apc/model/mpc2011/mpc2011en.htm"
-    strategy :page_match do |page|
-      page.scan(%r{href=.*?/(\d+)/V\d+/Ricoh_PS_Printers_Vol3_EXP_LIO[._-]v?(\d+(?:\.\d+)+)\.dmg}i).map do |match|
-        "#{match[1]},#{match[0]}"
-      end
+    regex(%r{href=.*?/(\d+)/V\d+/Ricoh_PS_Printers_Vol3_EXP_LIO[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/sandisk-security.rb
+++ b/Casks/sandisk-security.rb
@@ -9,9 +9,9 @@ cask "sandisk-security" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      page.scan(/href=.*?sandisk[._-]security[-_.]mac[-_.]v?(\d+(?:[-.]\d+)+)\.dmg/i)
-          .map { |match| match[0].tr("-", ".") }
+    regex(/href=.*?sandisk[._-]security[-_.]mac[-_.]v?(\d+(?:[-.]\d+)+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/smartscope.rb
+++ b/Casks/smartscope.rb
@@ -9,9 +9,9 @@ cask "smartscope" do
 
   livecheck do
     url "https://www.lab-nation.com/package/smartscope/macos/latest"
-    strategy :page_match do |page|
-      match = page[%r{/SmartScope/(\d+(?:/\d+)*)/MacOS/get}i, 1]
-      match.tr("/", ".")
+    regex(%r{/SmartScope/(\d+(?:/\d+)*)/MacOS/get}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("/", ".") }
     end
   end
 

--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -9,11 +9,9 @@ cask "synology-cloud-station-backup" do
 
   livecheck do
     url "https://www.synology.com/en-us/releaseNote/CloudStationBackup"
-    strategy :page_match do |page|
-      match = page.match(/Version:\s*(\d+(?:\.\d+)+)-(\d+)/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/Version:\s*(\d+(?:\.\d+)+)-(\d+)/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -9,10 +9,9 @@ cask "synology-drive" do
 
   livecheck do
     url "https://www.synology.com/en-us/releaseNote/SynologyDriveClient"
-    strategy :page_match do |page|
-      page.scan(/>\s*Version:\s*(\d+(?:\.\d+)+)-(\d+)\s*</i).map do |match|
-        "#{match[0]},#{match[1]}"
-      end
+    regex(/>\s*Version:\s*(\d+(?:\.\d+)+)-(\d+)\s*</i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/wd-security.rb
+++ b/Casks/wd-security.rb
@@ -9,9 +9,9 @@ cask "wd-security" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/WD_Security_Standalone_Installer_Mac_(\d+(?:_\d+)*)\.zip}i, 1]
-      v.tr("_", ".")
+    regex(%r{href=.*?/WD_Security_Standalone_Installer_Mac_(\d+(?:_\d+)*)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` blocks in this PR contain a `strategy` block that uses a regex internally. This PR updates these `livecheck` blocks to define the regex using `#regex` and simply pass the regex into the `strategy` block. This approach is preferable, as it aligns with how most `livecheck` blocks work, makes it easy to add/remove a `strategy` block in the future (i.e., the regex doesn't have to be manually moved into/out of the `strategy` block), allows the regex value to be surfaced in the `brew livecheck` debug and JSON output, and allows us to audit the regex.

[This approach can only be used with a single regex at the moment but I'll be creating a brew PR in the near future to allow `#regex` to handle multiple regexes. Once this is done, we can standardize on this approach for all related `strategy` blocks. In the interim time, I'm cleaning up `strategy` blocks that use one regex internally (starting with the smaller cask repositories). This is partly related to my ongoing work to address livecheck RuboCop offenses, as these changes resolve the `A regex is required if strategy :page_match is present` audit.]

---

This PR also updates some of these `strategy` blocks to use the `page.scan(regex).map { |match| ... }` approach instead of the multiline `match = page.match(regex)`/`next if match.blank?`/`"#{match[1]},#{match[2]}"` approach. The `#scan` approach is generally preferred because it will handle all matches in the content, whereas `#match` will only handle the first match (though in contexts where the content will only ever contain one match, we use `[regex, 1]` if the regex only has one capture group and the `#match` approach for more than one capture group`). Besides that, the `#scan` approach is generally less verbose.

One thing to note about converting from `#match` to `#scan` is that the capture group index numbers have to be decremented by one. Basically, the first capture group from `#scan` is index 0 but the first capture group index for `#match` is 1 instead (index 0 is the full matched text).

---

The only other thing to note here is that it's expected for the `3dconnexion` check to fail with an `Unable to get versions` error when run on macOS > Catalina, as the page for the beta driver has been removed. The beta driver page is still referenced on a related support page and there doesn't seem to be an alternative for macOS 11 or above at this point. This is upstream's problem and I don't think there's much we can do on our end other than removing the `livecheck` block in the `else` branch for the time being.