### PR TITLE
Update elgato-game-capture-hd from 2.11.12,3868 to 2.11.14

### DIFF
--- a/Casks/elgato-game-capture-hd.rb
+++ b/Casks/elgato-game-capture-hd.rb
@@ -2,18 +2,30 @@ cask "elgato-game-capture-hd" do
   if MacOS.version <= :yosemite
     version "2.0.5,983"
     sha256 "4803bcac9069e1e63a89e9053fdf2285487acf9e608e84f7610555075489ad5a"
+
+    url "https://gc-updates.elgato.com/mac/download.php?build=#{version.csv.second}"
   elsif MacOS.version <= :el_capitan
     version "2.9.2,1327"
     sha256 "9bcf01399719755034c964549a6a3af38932e7eaf03febc8b3742306505ca8a9"
+
+    url "https://gc-updates.elgato.com/mac/download.php?build=#{version.csv.second}"
   else
-    version "2.11.12,3868"
-    sha256 "a442281c2c2d0ec070463e1cf94d535946cbf813c7273e336e529e5897c764bb"
+    version "2.11.14"
+    sha256 "e00efce3433cad902400c610f4816fbecce414868a53aec70ef2d8ded9c1ba74"
   end
 
-  url "https://gc-updates.elgato.com/mac/download.php?build=#{version.csv.second}"
-  appcast "https://help.elgato.com/hc/en-us/articles/360027963512-Elgato-Game-Capture-HD-Software-Release-Notes-macOS"
+  url "https://edge.elgato.com/egc/macos/egcm/#{version}/final/Game_Capture_HD_#{version}.zip"
   name "Game Capture HD"
+  desc "Elgato video capture/streaming app"
   homepage "https://www.elgato.com/en/gaming/downloads/"
+
+  livecheck do
+    url "https://gc-updates.elgato.com/mac/egcm-update2-rss/?lang=English"
+    regex(/[_-]v?(\d+(?:\.\d+)+)\D+?$/i)
+    strategy :sparkle do |item, regex|
+      item.url[regex, 1]
+    end
+  end
 
   app "Game Capture HD.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `elgato-game-capture-hd` to the latest version, 2.11.14. The `url` format has changed for newer versions and this updates the setup accordingly but let me know if this isn't the preferred approach.

Besides that, this adds a `livecheck` block that checks the update feed the application uses when checking for new versions. I've seen the version in the filename differ from the Sparkle `version`/`shortVersion` in other Elgato software (e.g., `1.2.0` in the filename vs. `1.2` in the `shortVersion`), so I decided to match versions from the URL here. They also have a habit of changing the filename format for their software unexpectedly, so the regex is pretty loose at the moment (we can revisit it if we encounter issues in the future).