### PR TITLE
Update elgato-control-center from 1.1.4,10368 to 1.2.0,10411

### DIFF
--- a/Casks/elgato-control-center.rb
+++ b/Casks/elgato-control-center.rb
@@ -1,15 +1,21 @@
 cask "elgato-control-center" do
-  version "1.1.4,10368"
-  sha256 "bc65b948bc417b9c2be3e993c1042da0ab8745fa9748e0a50179bfd544b46c93"
+  version "1.2.0,10411"
+  sha256 "b7a81c663cd165da16e2ad75b928f9ed03e0eb0408b4ae7d08885a4b1a6e348b"
 
-  url "https://edge.elgato.com/egc/macos/eccm/#{version.csv.first}/Control_Center_#{version.csv.first}.#{version.csv.second}.zip"
+  url "https://edge.elgato.com/egc/macos/eccm/#{version.csv.first.major_minor}/ControlCenterMac-#{version.csv.first}.#{version.csv.second}.app.zip"
   name "Elgato Control Center"
   desc "Control your Elgato Key Lights"
   homepage "https://www.elgato.com/en/gaming/key-light"
 
   livecheck do
     url "https://gc-updates.elgato.com/mac/control-center-update/feed.xml"
-    strategy :sparkle
+    regex(/[_-]v?(\d+(?:\.\d{1,3})+)(?:\.(\d{4,}))?\D+?$/i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+    end
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `elgato-control-center` to the latest version, 1.2.0,10411. The `url` required some tweaks because the filename uses a `1.2.0` version format but the preceding path (and Sparkle shortVersion) use `1.2`. Additionally, the filename prefix has changed to `ControlCenterMac-` and a `.app` suffix is present in this version.

Besides that, this updates the `livecheck` block to identify the version from the item URL, due to the aforementioned mismatch between the filename version and Sparkle shortVersion. The filename version uses a  `1.2.0.10411` format, so it's necessary to split the build (if any) off of the end of the version string. I've done this by matching the build as a number that's four digits or more at the end of the version. [Alternatively, we could match 3+ digits (restricting the preceding numbers to 1-2 digits) but the build number should only increase, so it likely won't be necessary.]