### PR TITLE
Add dymo-label

### DIFF
--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -9,8 +9,7 @@ cask "dymo-label" do
   homepage "https://www.dymo.com/support?cfid=online-support"
 
   livecheck do
-    url "https://www.dymo.com/support?cfid=online-support"
-    regex(/href=.*?DCDMac[._-]?v?(\d+(?:\.\d+)+)\.pkg/i)
+    skip "curl is blocked by Cloudflare, so we can't check automatically"
   end
 
   pkg "DCDMac#{version}.pkg"

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -14,7 +14,8 @@ cask "dymo-label" do
     "com.dymo.dcd.webservice",
     "com.dymo.pnpd",
   ],
-            pkgutil:   "com.dymo.dymo-connect"
+            pkgutil:   "com.dymo.dymo-connect",
+            quit:      "com.dymo.DYMO-WebApi-Mac-Host"
 
   zap trash: "~/Library/Preferences/com.dymo.DYMO-WebApi-Mac-Host.plist"
 end

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -6,7 +6,7 @@ cask "dymo-label" do
       verified: "s3.amazonaws.com/download.dymo.com/dymo/Software/Mac/"
   name "Dymo Label"
   desc "Software for DYMO LabelWriters"
-  homepage "https://www.dymo.com/en-US/online-support"
+  homepage "https://www.dymo.com/support?cfid=online-support"
 
   livecheck do
     url "https://www.dymo.com/support?cfid=online-support"

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -1,0 +1,23 @@
+cask "dymo-label" do
+  version "1.4.3.103"
+  sha256 "b490b687ed24af5a198ce215d68e041b6efc5d5e2f83ced6f5e5b788b52142f1"
+
+  url "https://s3.amazonaws.com/download.dymo.com/dymo/Software/Mac/DCDMac#{version}.pkg"
+  name "Dymo Label"
+  desc "Software for DYMO LabelWriters"
+  homepage "https://www.dymo.com/en-US/online-support"
+
+  pkg "DCDMac#{version}.pkg"
+
+  uninstall launchctl: [
+    "com.dymo.dcd.webservice",
+    "com.dymo.pnpd",
+  ],
+  pkgutil:   [
+    "com.dymo.dymo-connect",
+  ]
+
+  zap trash: [
+    "~/Library/Preferences/com.dymo.DYMO-WebApi-Mac-Host.plist",
+  ]
+end

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -9,7 +9,7 @@ cask "dymo-label" do
   homepage "https://www.dymo.com/support?cfid=online-support"
 
   livecheck do
-    skip "curl is blocked by Cloudflare, so we can't check automatically"
+    skip "No version information available"
   end
 
   pkg "DCDMac#{version}.pkg"

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -2,7 +2,8 @@ cask "dymo-label" do
   version "1.4.3.103"
   sha256 "b490b687ed24af5a198ce215d68e041b6efc5d5e2f83ced6f5e5b788b52142f1"
 
-  url "https://s3.amazonaws.com/download.dymo.com/dymo/Software/Mac/DCDMac#{version}.pkg"
+  url "https://s3.amazonaws.com/download.dymo.com/dymo/Software/Mac/DCDMac#{version}.pkg",
+    verified: "s3.amazonaws.com/download.dymo.com"
   name "Dymo Label"
   desc "Software for DYMO LabelWriters"
   homepage "https://www.dymo.com/en-US/online-support"

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -8,6 +8,11 @@ cask "dymo-label" do
   desc "Software for DYMO LabelWriters"
   homepage "https://www.dymo.com/en-US/online-support"
 
+  livecheck do
+    url "https://www.dymo.com/support?cfid=online-support"
+    regex(/href=.*?DCDMac[._-]?v?(\d+(?:\.\d+)+)\.pkg/i)
+  end
+
   pkg "DCDMac#{version}.pkg"
 
   uninstall launchctl: [

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -3,7 +3,7 @@ cask "dymo-label" do
   sha256 "b490b687ed24af5a198ce215d68e041b6efc5d5e2f83ced6f5e5b788b52142f1"
 
   url "https://s3.amazonaws.com/download.dymo.com/dymo/Software/Mac/DCDMac#{version}.pkg",
-    verified: "s3.amazonaws.com/download.dymo.com"
+      verified: "s3.amazonaws.com/download.dymo.com/dymo/Software/Mac/"
   name "Dymo Label"
   desc "Software for DYMO LabelWriters"
   homepage "https://www.dymo.com/en-US/online-support"
@@ -14,11 +14,7 @@ cask "dymo-label" do
     "com.dymo.dcd.webservice",
     "com.dymo.pnpd",
   ],
-  pkgutil:   [
-    "com.dymo.dymo-connect",
-  ]
+            pkgutil:   "com.dymo.dymo-connect"
 
-  zap trash: [
-    "~/Library/Preferences/com.dymo.DYMO-WebApi-Mac-Host.plist",
-  ]
+  zap trash: "~/Library/Preferences/com.dymo.DYMO-WebApi-Mac-Host.plist"
 end


### PR DESCRIPTION
Since #2233, it seems that Dymo has completely redone their desktop
software, and now offers a direct S3 download link. I was able to
install and uninstall using this cask.