### PR TITLE
Remove `depends_on` references to Yosemite

### DIFF
--- a/Casks/3dconnexion.rb
+++ b/Casks/3dconnexion.rb
@@ -20,7 +20,7 @@ cask "3dconnexion" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   pkg "Install 3Dconnexion software.pkg"
 

--- a/Casks/8bitdo-firmware-updater.rb
+++ b/Casks/8bitdo-firmware-updater.rb
@@ -12,8 +12,6 @@ cask "8bitdo-firmware-updater" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "8BitDo Firmware Updater.app"
 
   uninstall quit: "com.Dev.Sihoo.-BitDoFirmwareUpdater"

--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -13,7 +13,7 @@ cask "blackvue-viewer" do
     regex(/blackvue-cloud-viewer-(\d+(?:\.\d+)+)-mac\.zip/i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   app "BlackVue Viewer.app"
 end

--- a/Casks/canon-fax.rb
+++ b/Casks/canon-fax.rb
@@ -8,8 +8,6 @@ cask "canon-fax" do
   desc "Fax driver & utilities for Canon imageCLASS MF printers"
   homepage "https://www.usa.canon.com/internet/portal/us/home/support/drivers-downloads"
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Canon_FAX_Installer.pkg"
 
   uninstall pkgutil: "jp.co.canon.CUPSFAX.*"

--- a/Casks/canon-mf-printer.rb
+++ b/Casks/canon-mf-printer.rb
@@ -12,7 +12,7 @@ cask "canon-mf-printer" do
     skip "No version information available"
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   pkg "MF_Printer_Installer.pkg"
 

--- a/Casks/canon-pixma25xx-printer.rb
+++ b/Casks/canon-pixma25xx-printer.rb
@@ -19,8 +19,6 @@ cask "canon-pixma25xx-printer" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "PrinterDriver_MG2500 series_#{format("%<major>02d%<minor>02d%<patch>02d", major: version.major, minor: version.minor, patch: version.patch.to_i)}.pkg"
 
   uninstall pkgutil: "jp.co.canon.pkg.MG2500-#{format("%<major>02d%<minor>02d%<patch>02d", major: version.major, minor: version.minor, patch: version.patch.to_i)}"

--- a/Casks/canon-pixma72xx-printer.rb
+++ b/Casks/canon-pixma72xx-printer.rb
@@ -12,8 +12,6 @@ cask "canon-pixma72xx-printer" do
     skip "No version information available"
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "PrinterDriver_iP7200 series_#{format("%<major>02d%<minor>02d%<patch>02d", major: version.major, minor: version.minor, patch: version.patch.to_i)}.pkg"
 
   uninstall pkgutil: "jp.co.canon.pkg.iP7200-#{format("%<major>02d%<minor>02d%<patch>02d", major: version.major, minor: version.minor, patch: version.patch.to_i)}"

--- a/Casks/canon-scangear-mf.rb
+++ b/Casks/canon-scangear-mf.rb
@@ -8,8 +8,6 @@ cask "canon-scangear-mf" do
   desc "Scanner driver & utilities for Canon imageCLASS MF printers"
   homepage "https://www.usa.canon.com/internet/portal/us/home/support/drivers-downloads"
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Canon_ScanGear_MF.pkg"
 
   uninstall launchctl: [

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -17,8 +17,6 @@ cask "concept2-utility" do
     regex(/Concept2\s+Utility\s+(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Concept2 Utility #{version}.pkg"
 
   uninstall pkgutil: "com.concept2.pkg.Concept2Utility"

--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -24,8 +24,6 @@ cask "garmin-basecamp" do
   desc "3D mapping application"
   homepage "https://www.garmin.com/en-US/shop/downloads/basecamp"
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Install BaseCamp.pkg"
 
   uninstall quit:    [

--- a/Casks/konica-minolta-bizhub-c750i-driver.rb
+++ b/Casks/konica-minolta-bizhub-c750i-driver.rb
@@ -32,7 +32,7 @@ cask "konica-minolta-bizhub-c750i-driver" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   uninstall pkgutil: "jp.konicaminolta.print.package.C750i"
 end

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -1,5 +1,5 @@
 cask "logitech-unifying" do
-  if MacOS.version <= :mojave
+  if MacOS.version <= :yosemite
     version "1.2.359"
     sha256 "e6fd9c1b536033f3346b32c391bd58587ea9f549cab7839cf8a1dbc62a739825"
   else
@@ -16,8 +16,6 @@ cask "logitech-unifying" do
     url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=ec9eb8f1-8e0b-11e9-a62b-5b664cf4d3da"
     regex(/unifying(\d+(?:\.\d+)+)_mac\.zip/i)
   end
-
-  depends_on macos: ">= :yosemite"
 
   pkg "Unifying Installer.app/Contents/Resources/Logitech Unifying Signed.mpkg"
 

--- a/Casks/mazda-toolbox.rb
+++ b/Casks/mazda-toolbox.rb
@@ -9,8 +9,6 @@ cask "mazda-toolbox" do
   name "Mazda Toolbox"
   homepage "https://infotainment.mazdahandsfree.com/navigation-updatemymaps"
 
-  depends_on macos: ">= :yosemite"
-
   app "Mazda Toolbox.app"
 
   uninstall signal: [

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -20,12 +20,7 @@ cask "nvidia-web-driver" do
   name "NVIDIA Web Driver"
   homepage "https://www.nvidia.com/Download/index.aspx"
 
-  depends_on macos: [
-    :yosemite,
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-  ]
+  depends_on macos: "<= :high_sierra"
 
   pkg "WebDriver-#{version}.pkg"
 

--- a/Casks/plantronics-hub.rb
+++ b/Casks/plantronics-hub.rb
@@ -6,7 +6,7 @@ cask "plantronics-hub" do
   name "Plantronics Hub"
   homepage "https://www.poly.com/us/en/support/downloads-apps"
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :mojave"
 
   pkg "Plantronics Software.pkg"
 

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -35,8 +35,6 @@ cask "roland-quad-capture-usb-driver" do
   name "Roland Quad-Capture USB Driver"
   homepage "https://www.roland.com/us/products/quad-capture/"
 
-  depends_on macos: ">= :yosemite"
-
   uninstall pkgutil:   "jp.co.roland.QuadCapture.*",
             launchctl: [
               "jp.co.roland.RDUSB0000Setupd",


### PR DESCRIPTION
This is the first stages of removing `:yosemite` references from Homebrew/cask-drivers (Yosemite support will be removed from Homebrew 3.5.0).

This PR removes, corrects or simplifies all `depends_on` lines referencing Yosemite. 

This PR does _not_ remove any conditions like `MacOS.version <= :yosemite`. I do not intend to make any changes that remove Yosemite support until _after_ 3.5.0 - the changes so far should be harmless for Yosemite users.