### PR TITLE
Remove Yosemite support

### DIFF
--- a/Casks/elgato-game-capture-hd.rb
+++ b/Casks/elgato-game-capture-hd.rb
@@ -1,10 +1,5 @@
 cask "elgato-game-capture-hd" do
-  if MacOS.version <= :yosemite
-    version "2.0.5,983"
-    sha256 "4803bcac9069e1e63a89e9053fdf2285487acf9e608e84f7610555075489ad5a"
-
-    url "https://gc-updates.elgato.com/mac/download.php?build=#{version.csv.second}"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.9.2,1327"
     sha256 "9bcf01399719755034c964549a6a3af38932e7eaf03febc8b3742306505ca8a9"
 

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -1,11 +1,6 @@
 cask "logitech-unifying" do
-  if MacOS.version <= :yosemite
-    version "1.2.359"
-    sha256 "e6fd9c1b536033f3346b32c391bd58587ea9f549cab7839cf8a1dbc62a739825"
-  else
-    version "1.3.375"
-    sha256 "82fe3df612e775ec8789fa821f4f62d4b3a55278276d03474580fee668ee50b7"
-  end
+  version "1.3.375"
+  sha256 "82fe3df612e775ec8789fa821f4f62d4b3a55278276d03474580fee668ee50b7"
 
   url "https://download01.logi.com/web/ftp/pub/controldevices/unifying/unifying#{version}_mac.zip"
   name "Logitech Unifying Software"

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,8 +1,5 @@
 cask "nvidia-web-driver" do
-  if MacOS.version <= :yosemite
-    version "346.02.03f14"
-    sha256 "21df2785257c58b940168b4d4ff73e32f71e9f7e28ed879bf0d605e4abc74aef"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "346.03.15f16"
     sha256 "f0c1a23a262ba6db35f1d7a0da39e7b7648805d63d65be20af33e582cc7050bc"
   elsif MacOS.version <= :sierra

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -1,11 +1,5 @@
 cask "roland-quad-capture-usb-driver" do
-  if MacOS.version <= :yosemite
-    version "1.5.2,10"
-    sha256 "da575f4b3874e0042fddffb4462f4521019ceaa3f44942f64bce099b426cf2d1"
-    url "https://static.roland.com/assets/media/tgz/quad_mx#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
-
-    pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
-  elsif MacOS.version <= :sierra
+  if MacOS.version <= :sierra
     version "1.5.3,12"
     sha256 "712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770"
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -1,9 +1,5 @@
 cask "xerox-print-driver" do
-  if MacOS.version <= :yosemite
-    version "3.123.0_1865"
-    sha256 "ac9c013705742538c0faa5df2194e3a7d4fb9980dd0570e41b213ff87172ee6c"
-    url "https://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1010/ar/XeroxPrintDriver_#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "4.17.1_1980"
     sha256 "36b1ddf1f598ceaf6f91d38b0d228be3f8f6188c251761424cbea7a869488883"
     url "https://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1011/pt_BR/XeroxPrintDriver_#{version}.dmg"


### PR DESCRIPTION
This is the final stage of removing `:yosemite` references from Homebrew/cask-drivers.

Homebrew 3.5.0 released on Monday 6th and since that release, `brew` no longer runs on Yosemite. Therefore we can now remove the remaining Yosemite conditionals here.

Homebrew taps are not expected to be backwards compatible with older releases, but I gave a few days of leeway anyway.