### PR TITLE
yubico-yubikey-personalization-gui: discontinued

### DIFF
--- a/Casks/yubico-yubikey-personalization-gui.rb
+++ b/Casks/yubico-yubikey-personalization-gui.rb
@@ -7,11 +7,6 @@ cask "yubico-yubikey-personalization-gui" do
   desc "YubiKey tool"
   homepage "https://www.yubico.com/products/services-software/personalization-tools/use/"
 
-  livecheck do
-    url "https://github.com/Yubico/yubikey-personalization-gui.git"
-    strategy :git
-  end
-
   pkg "yubikey-personalization-gui-#{version}.pkg"
 
   uninstall quit:    "com.yubico.YKPersonalization",
@@ -21,4 +16,10 @@ cask "yubico-yubikey-personalization-gui" do
     "~/Library/Application Scripts/com.yubico.YKPersonalization",
     "~/Library/Containers/com.yubico.YKPersonalization",
   ]
+
+  # "This project is no longer under active development. Use YubiKey Manager
+  # to configure a YubiKey device."
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `README` in the [GitHub repository for `yubico-yubikey-personalization-gui`](https://github.com/Yubico/yubikey-personalization-gui) contains a note saying:

> This project is no longer under active development. Use YubiKey Manager ([GUI](https://developers.yubico.com/yubikey-manager-qt/), [CLI](https://developers.yubico.com/yubikey-manager/)) to configure a YubiKey device.

The homepage also states:

> This project is supported but no longer under active development.

With that in mind, this PR adds a `discontinued` caveat and removes the `livecheck` block so it will be automatically skipped.