### PR TITLE
Use `arch` and `on_arch_conditional` DSLs

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -1,5 +1,5 @@
 cask "lmsclients-squeezeplay" do
-  arch = Hardware::CPU.intel? ? "x86_64" : "M1"
+  arch arm: "M1", intel: "x86_64"
 
   version "8.0.1r1382"
 

--- a/Casks/muteme.rb
+++ b/Casks/muteme.rb
@@ -1,5 +1,5 @@
 cask "muteme" do
-  arch = Hardware::CPU.intel? ? "osx_64" : "osx_arm64"
+  arch arm: "osx_arm64", intel: "osx_64"
 
   version "0.11.3"
 

--- a/Casks/sony-rcs300.rb
+++ b/Casks/sony-rcs300.rb
@@ -1,5 +1,5 @@
 cask "sony-rcs300" do
-  arch = Hardware::CPU.intel? ? "" : "1"
+  arch arm: "1"
 
   version "1.0.0"
 


### PR DESCRIPTION
This PR modifies some casks to use the new `arch` and `on_arch_conditional` DSLs instead of `arch = Hardware::CPU.intel? ? "intel" : "arm"`. All casks in this PR were modified using `brew style --fix` after checking out https://github.com/Homebrew/brew/pull/13681.

I've verified that everything is working as expected by running `brew info --json=v2` on these casks before and after the changes in this PR (I check on both Intel and ARM). There were no differences, indicating that all URLs remain the same after these changes.
