### PR TITLE
Use `on_intel` and `on_arm` blocks

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -3,9 +3,10 @@ cask "lmsclients-squeezeplay" do
 
   version "8.0.1r1382"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "bcc278b08d367d47bfceba1b1adad40564bc0062c31014bd29ed9e3e60cbafe1"
-  else
+  end
+  on_arm do
     sha256 "a06f0f2a55bb82f7dbf7dd8408f39292eaed20c61d8ccde5ee42b0e24e14ac11"
   end
 

--- a/Casks/muteme.rb
+++ b/Casks/muteme.rb
@@ -3,9 +3,10 @@ cask "muteme" do
 
   version "0.11.3"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "c078c558debb048eab39f23f80bdc9e978b968b0d64b88a47bf1ca5f96955364"
-  else
+  end
+  on_arm do
     sha256 "ad648d8194d2f81a8e1d5fa4fbb122307f2103bfbb6671ff0c252336f896a7db"
   end
 

--- a/Casks/reinersct-cyberjack.rb
+++ b/Casks/reinersct-cyberjack.rb
@@ -3,9 +3,10 @@ cask "reinersct-cyberjack" do
 
   version "3.99.5final.SP15"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "721c0cf3f82d863acd5c070b58961dcd890a035dd339563a5959b5f124d75820"
-  else
+  end
+  on_arm do
     sha256 "bea7c3ae2e146b9216b805e611507bfa614c0c768c1206a53c07b6e7c33c7836"
   end
 

--- a/Casks/sony-rcs300.rb
+++ b/Casks/sony-rcs300.rb
@@ -3,9 +3,10 @@ cask "sony-rcs300" do
 
   version "1.0.0"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "55183d65fc180544ac58ab3a6851980f63d47afdfc2b447ab9416bee7f32f99b"
-  else
+  end
+  on_arm do
     sha256 "429f0481a2a04c2a31579ac9b26716c343633342b112130660e5e79a701c10b9"
   end
 


### PR DESCRIPTION
This PR changes all casks in this repo to use `on_arm` and `on_intel` blocks instead of `if Hardware::CPU.intel?`. The changes in this PR were made by running `brew style --fix homebrew/cask` using the style rules that are were added in https://github.com/Homebrew/brew/pull/13698.

As before, I've run `brew info --json=v2 --all` both before and after these changes and compared the results. On both Intel and ARM, there were no differences.

See also: https://github.com/Homebrew/homebrew-cask/pull/129760