### PR TITLE
Use `sha256 arm: "...", intel: "..."`

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -2,13 +2,8 @@ cask "lmsclients-squeezeplay" do
   arch arm: "M1", intel: "x86_64"
 
   version "8.0.1r1382"
-
-  on_intel do
-    sha256 "bcc278b08d367d47bfceba1b1adad40564bc0062c31014bd29ed9e3e60cbafe1"
-  end
-  on_arm do
-    sha256 "a06f0f2a55bb82f7dbf7dd8408f39292eaed20c61d8ccde5ee42b0e24e14ac11"
-  end
+  sha256 arm:   "a06f0f2a55bb82f7dbf7dd8408f39292eaed20c61d8ccde5ee42b0e24e14ac11",
+         intel: "bcc278b08d367d47bfceba1b1adad40564bc0062c31014bd29ed9e3e60cbafe1"
 
   url "https://downloads.sourceforge.net/lmsclients/SqueezePlay-#{arch}-#{version}.dmg",
       verified: "downloads.sourceforge.net/lmsclients/"

--- a/Casks/muteme.rb
+++ b/Casks/muteme.rb
@@ -2,13 +2,8 @@ cask "muteme" do
   arch arm: "osx_arm64", intel: "osx_64"
 
   version "0.12.1"
-
-  on_intel do
-    sha256 "5b722eb9d4fca914791e9167995d1870505c800600ddd69101374681f313e380"
-  end
-  on_arm do
-    sha256 "d54d8b292937e76df85b6a462ea52416232e105637c91f0038aa497eba61f32e"
-  end
+  sha256 arm:   "d54d8b292937e76df85b6a462ea52416232e105637c91f0038aa497eba61f32e",
+         intel: "5b722eb9d4fca914791e9167995d1870505c800600ddd69101374681f313e380"
 
   url "https://muteme.io/download/flavor/default/#{version}/#{arch}/MuteMe-Client-#{version}.dmg",
       verified: "muteme.io/download/flavor/default/"

--- a/Casks/reinersct-cyberjack.rb
+++ b/Casks/reinersct-cyberjack.rb
@@ -2,13 +2,8 @@ cask "reinersct-cyberjack" do
   arch arm: "arm64", intel: "x86_64"
 
   version "3.99.5final.SP15"
-
-  on_intel do
-    sha256 "721c0cf3f82d863acd5c070b58961dcd890a035dd339563a5959b5f124d75820"
-  end
-  on_arm do
-    sha256 "bea7c3ae2e146b9216b805e611507bfa614c0c768c1206a53c07b6e7c33c7836"
-  end
+  sha256 arm:   "bea7c3ae2e146b9216b805e611507bfa614c0c768c1206a53c07b6e7c33c7836",
+         intel: "721c0cf3f82d863acd5c070b58961dcd890a035dd339563a5959b5f124d75820"
 
   url "https://support.reiner-sct.de/downloads/MAC/pcsc-cyberjack_#{version}-#{arch}-signed.pkg"
   name "reinersct-cyberjack"

--- a/Casks/sony-rcs300.rb
+++ b/Casks/sony-rcs300.rb
@@ -2,13 +2,8 @@ cask "sony-rcs300" do
   arch arm: "1"
 
   version "1.0.0"
-
-  on_intel do
-    sha256 "55183d65fc180544ac58ab3a6851980f63d47afdfc2b447ab9416bee7f32f99b"
-  end
-  on_arm do
-    sha256 "429f0481a2a04c2a31579ac9b26716c343633342b112130660e5e79a701c10b9"
-  end
+  sha256 arm:   "429f0481a2a04c2a31579ac9b26716c343633342b112130660e5e79a701c10b9",
+         intel: "55183d65fc180544ac58ab3a6851980f63d47afdfc2b447ab9416bee7f32f99b"
 
   url "https://www.sony.co.jp/Products/felica/consumer/support/download/driver/usbdriver/usbdriver#{arch}-s300-v#{version}.dmg"
   name "SONY USB Driver for RC-S300"


### PR DESCRIPTION
This PR changes all casks in this repo to use the new `sha256 arm: "...", intel: "..."` DSL instead of nesting only a single `sha256` in `on_arm` and `on_intel` blocks.

The changes in this PR were made by running `brew style --fix homebrew/cask-drivers` using the style rules that are being worked on in https://github.com/Homebrew/brew/pull/13703.

As before, I've run `brew info --json=v2 --all` both before and after these changes and compared the results. On both Intel and ARM, there were no differences.

See also: https://github.com/Homebrew/brew/pull/13702
See also: https://github.com/Homebrew/homebrew-cask/pull/130260
