### PR TITLE
Bump asix ax88179 2.1.0

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -30,9 +30,9 @@ cask "asix-ax88179" do
       end
     end
   elsif MacOS.version <= :big_sur
-    version "1.3.0,1163"
+    version "1.3.0,1301"
 
-    container nested: "ASIX_USB_Device_Installer_macOS_11.3_to11.6_Driver_v#{version.before_comma}/ASIX_USB_Device_Installer_v#{version.before_comma}.dmg"
+    container nested: "ASIX_USB_Device_Installer_macOS_11.3_to11.6_Driver_v#{version.before_comma}_20220706/ASIX_USB_Device_Installer_v#{version.before_comma}.dmg"
     pkg "ASIX_USB_Device_Installer_v#{version.before_comma}.pkg"
 
     livecheck do
@@ -87,6 +87,7 @@ cask "asix-ax88179" do
     "com.asix.pkg.ASIXUSBDeviceAppInstaller",
     "com.mygreatcompany.pkg.AX88179178A",
     "com.mygreatcompany.pkg.AX88179A772DDEXTAPPUninistaller",
+    "com.mygreatcompany.pkg.ASIXUSBDeviceAPPUninstall",
   ]
 
   caveats do

--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -45,7 +45,7 @@ cask "asix-ax88179" do
       end
     end
   else
-    version "2.0.0,1179"
+    version "2.1.0,1307"
 
     container nested: "ASIX_USB_Device_Installer_macOS_12_Driver_v#{version.before_comma}/ASIX_USB_Device_Installer_v#{version.before_comma}.dmg"
     pkg "ASIX_USB_Device_Installer_v#{version.before_comma}.pkg"


### PR DESCRIPTION
This should fix the macOS 11 CI errors encountered on the previous PRs but the hardcoded path needs to be manually changed if the 1.3.0 release is ever updated. I welcome any improvements.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
