### PR TITLE
nitrokey: update livecheck

### DIFF
--- a/Casks/nitrokey.rb
+++ b/Casks/nitrokey.rb
@@ -8,10 +8,13 @@ cask "nitrokey" do
   desc "Application to manage Nitro Key devices"
   homepage "https://www.nitrokey.com/download/macos"
 
+  # GitHub releases aren't guaranteed to provide the dmg file we use, so it
+  # would be necessary to fetch the assets list for each stable release until
+  # we find one with a dmg file. This involves a comparatively large number of
+  # requests which will increase with each new release that doesn't include a
+  # dmg file, so this approach arguably isn't tenable for us.
   livecheck do
-    url "https://github.com/Nitrokey/nitrokey-app/releases"
-    strategy :page_match
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/Nitrokey-App\.dmg}i)
+    skip "Requires checking assets for multiple releases"
   end
 
   app "Nitrokey App v#{version}.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `nitrokey` identifies versions from a dmg file in release assets lists. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

The upstream GitHub releases don't reliably provide a dmg file (some only provide a tarball, exe, etc.), so it would be necessary to cycle through releases and fetch the assets list HTML for each until we find the newest one with a dmg file. This currently involves four requests but it would continue to grow with each subsequent release until the next dmg is available. Due to the unpredictable and comparatively large number of requests involved, I'm against that approach.

Unfortunately, the [first-party download page](https://www.nitrokey.com/download/macos) simply links to the "latest" GitHub release instead of directly linking to the newest dmg file. Ironically, the "latest" GitHub release currently doesn't provide an asset for macOS.

With this in mind, I've simply set the `livecheck` block to skip for now. [If someone wants to open an issue in the GitHub repository asking them to use a direct link to the latest dmg on the macOS download page (and make sure to update it promptly when a new version is available) feel free, as that would allow us to create a working check here. I'm currently focusing on fixing these broken checks and don't have time to bother upstream about it.]