### PR TITLE
uhk-agent: update livecheck

### DIFF
--- a/Casks/uhk-agent.rb
+++ b/Casks/uhk-agent.rb
@@ -9,9 +9,8 @@ cask "uhk-agent" do
   homepage "https://github.com/UltimateHackingKeyboard/agent"
 
   livecheck do
-    url :url
-    strategy :github_latest
-    regex(/href=.*?UHK[._-]Agent[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
+    url "https://github.com/UltimateHackingKeyboard/agent/releases/latest"
+    strategy :header_match
   end
 
   app "UHK Agent.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `uhk-agent` identifies versions from the dmg file in the "latest" release assets list. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

The releases appear to reliably provide a dmg file, so it's not necessary to identify the version from the filename in this case and we can simply match it from the release tag. However, the default `GithubLatest` regex will also match the firmware version from the release description. We can use a regex to try to avoid this but that may fail and it would be more reliable to match the version from the `location` header of the response.

This PR updates the `livecheck` block to use the `HeaderMatch` strategy with the "latest" release URL for the time being. In the long run, I will be updating the `GithubLatest` strategy to match the version from the `location` header but there's some preceding work that I need to do before that can happen.