### PR TITLE
Create Epson Drivers/Utilities

### DIFF
--- a/Casks/epson-photo-plus.rb
+++ b/Casks/epson-photo-plus.rb
@@ -1,0 +1,22 @@
+cask "epson-photo-plus" do
+  version "3.7.0"
+  sha256 "eaa02b81cb01aed495d2493fc062b909c9fb068a6ab8f867084fa4f227280c01"
+
+  url "https://ftp.epson.com/drivers/EPPlus_#{version.no_dots}.dmg"
+  name "Epson Photo+"
+  desc "Arrange and print photos, including direct printing to discs"
+  homepage "https://epson.com/"
+
+  livecheck do
+    url "https://epson.com/Support/Printers/Single-Function-Inkjet-Printers/SureColor-Series/Epson-SureColor-P900/s/SPT_C11CH37201"
+    strategy :page_match
+    regex(/\s*Epson\sPhoto\+[\s(?:&nbsp;)]+v(\d+(?:\.\d+)+)/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :el_capitan"
+
+  pkg "Epson Photo Plus.pkg"
+
+  uninstall pkgutil: "com.epson.pkg.EpsonPhotoPlus"
+end

--- a/Casks/epson-print-layout.rb
+++ b/Casks/epson-print-layout.rb
@@ -1,0 +1,26 @@
+cask "epson-print-layout" do
+  version "1.5.5"
+  sha256 "96d7b7d55a2f81e39cfa7a71605e37c8bf68b8429a8f30de730292cef83a1b88"
+
+  url "https://ftp.epson.com/drivers/EPL_#{version.no_dots}.dmg"
+  name "Epson Print Layout"
+  desc "Quick and easy color-managed printing"
+  homepage "https://epson.com/"
+
+  livecheck do
+    url "https://epson.com/epson-print-layout"
+    regex(%r{href=.*?/EPL_(\d+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match&.first&.gsub(/(\d)(?!$)/, '\1.')
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :el_capitan"
+
+  pkg "Epson Print Layout.pkg"
+
+  uninstall pkgutil: "com.epson.printlayout.pkg"
+end

--- a/Casks/epson-surecolor-p900.rb
+++ b/Casks/epson-surecolor-p900.rb
@@ -1,0 +1,26 @@
+cask "epson-surecolor-p900" do
+  version :latest
+  sha256 :no_check
+
+  url "https://ftp.epson.com/drivers/SCP900_Lite_64NR_NA.dmg"
+  name "Epson SureColor P900 Driver & Utilities Package"
+  desc "Printer Driver, Media Installer, & Software Updater"
+  homepage "https://epson.com/"
+
+  depends_on macos: ">= :el_capitan"
+
+  installer manual: "EPSON.app"
+
+  uninstall pkgutil: [
+    "com.aviatainc.p3.epson",
+    "com.epson.emx.p900",
+    "com.epson.ens.430",
+    "com.epson.epsvcp",
+    "com.epson.guide.surecolor_p700_p900.en",
+    "com.epson.pkg.ema",
+    "com.epson.pkg.ijpdrv.sc-p900series.a.Machine_104_and_later",
+    "com.epson.pkg.ijpdrv.sc-p900series.a.Machine_105_and_later",
+    "com.epson.pkg.ijpdrv.sc-p900series.a.Module_107_and_later",
+    "com.epson.pkg.ijpdrv.sc-p900series.a.USBClassDriver_107_and_later",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.


### Reopening https://github.com/Homebrew/homebrew-cask-drivers/pull/3038 with adjustments after original review

#### https://github.com/Homebrew/homebrew-cask-drivers/pull/3038#discussion_r995318681
> This appears to identify the Epson Photo+ version from a page that's specifically made for the Epson SureColor P900. If/when that model becomes unsupported in the future, presumably this page won't provide the latest version information anymore. Is there a source for this information that's not tied to a specific model?
> 
> If this is the only available source for this version information, I'll provide a suggestion to tweak this `livecheck` block to bring it up to standard.

Epson Photo+ is included on all compatible printers' pages, but it does not appear to have a dedicated, agnostic page, nor does there appear to be a page collecting all Epson software.

#### https://github.com/Homebrew/homebrew-cask-drivers/pull/3038#pullrequestreview-1141784274
> In general, we try to avoid reconstituting a version in livecheck by inserting dots as numbers without a delimiter are inherently ambiguous and this approach will eventually lead to issues. Basically, this works when the numeric version parts are all single digits (e.g., `123` -> `1.2.3`) but it will produce an incorrect version if any of the parts are more than one digit (e.g., `1234` -> `1.2.3.4` instead of `12.3.4`, `1.23.4`, or `1.2.34`). In this type of situation, it's preferable to match the version from text where the version is already formatted with a delimiter.
> 
> If you're unable to find a page where the version is formatted and we're only left with reconstituting the version from the digits in the filename, I suppose it would technically work to some degree because we simply use `version.no_dots` in the `url`. That said, the version is liable to end up being incorrect eventually (unless upstream specifically avoids 2+ digit version parts).

Pulling the Epson Photo+ version from the text on the page rather than from the download's filename.

Thank you in advance for any help and suggestions!