### PR TITLE
Fix checksum of droidcam-obs 1.6.0

### DIFF
--- a/Casks/droidcam-obs.rb
+++ b/Casks/droidcam-obs.rb
@@ -1,6 +1,6 @@
 cask "droidcam-obs" do
   version "1.6.0"
-  sha256 "040e80cfe5469ae98f50206f58a218bc9efed36b11cafdc447659ed42e37988e"
+  sha256 "e4a697f1a7dc673cc6e03fa04c4c5d647b5bb0996746cf9a8d4857b4c1e0c431"
 
   url "https://github.com/dev47apps/droidcam-obs-plugin/releases/download/#{version}/DroidCamOBS_#{version}_macos.pkg",
       verified: "github.com/dev47apps/droidcam-obs-plugin/"


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

I've asked the developers via email what could be the reason for the checksum mismatch and for completeness I will recite the relevant part of the answer:

> There must have been a hotfix uploaded without a new release/tag - the OBS plugin bundle structure has changed with v28 so it was a packaging issue.
You can verify the package is legitimate by checking its signature: opening the pkg installer and clicking the lock icon in the corner should show DEV47 APPS LTD.

I've also checked whether the signature is valid as pointed out by the developer and this seems to be the case.