### PR TITLE
Add RJM Mastermind GT and Mini Effect Gizmo X editor software

### DIFF
--- a/Casks/rjm-megxeditor.rb
+++ b/Casks/rjm-megxeditor.rb
@@ -14,5 +14,9 @@ cask "rjm-megxeditor" do
 
   app "MEGXEditor.app"
 
-  zap trash: "~/Library/Preferences/com.rjmmusic.www.MEGX Editor.plist"
+  zap trash: [
+    "~/Library/Caches/RJM Music Technology, Inc./MEGX Editor",
+    "~/Library/Preferences/com.rjmmusic.www.MEGX Editor.plist",
+    "~/Library/Preferences/com.RJMMusicTechnology.MEGXEditor.plist"
+  ]
 end

--- a/Casks/rjm-megxeditor.rb
+++ b/Casks/rjm-megxeditor.rb
@@ -13,4 +13,6 @@ cask "rjm-megxeditor" do
   end
 
   app "MEGXEditor.app"
+
+  zap trash: "~/Library/Preferences/com.rjmmusic.www.MEGX Editor.plist"
 end

--- a/Casks/rjm-megxeditor.rb
+++ b/Casks/rjm-megxeditor.rb
@@ -1,0 +1,16 @@
+cask "rjm-megxeditor" do
+  version "1.1.1"
+  sha256 "a08d3f34b26dc8d1153319af64410c770c38abc4e29ed1ebd728bf7c14121c25"
+
+  url "https://www.rjmmusic.com/downloads/MEGX/MEGXEditor-#{version}.dmg"
+  name "RJM Music Mini Effect Gizmo X Editor"
+  desc "Editor software to configure RJM mini effect gizmo X MIDI audio loop switcher"
+  homepage "https://www.rjmmusic.com/"
+
+  livecheck do
+    url "https://www.rjmmusic.com/wp-json/wp/v2/pages/6614"
+    regex(/href=.*?MEGXEditor[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
+  app "MEGXEditor.app"
+end

--- a/Casks/rjm-megxeditor.rb
+++ b/Casks/rjm-megxeditor.rb
@@ -17,6 +17,6 @@ cask "rjm-megxeditor" do
   zap trash: [
     "~/Library/Caches/RJM Music Technology, Inc./MEGX Editor",
     "~/Library/Preferences/com.rjmmusic.www.MEGX Editor.plist",
-    "~/Library/Preferences/com.RJMMusicTechnology.MEGXEditor.plist"
+    "~/Library/Preferences/com.RJMMusicTechnology.MEGXEditor.plist",
   ]
 end

--- a/Casks/rjm-mmgteditor.rb
+++ b/Casks/rjm-mmgteditor.rb
@@ -17,6 +17,6 @@ cask "rjm-mmgteditor" do
   zap trash: [
     "~/Library/Preferences/com.rjmmusic.MMGTEditor.plist",
     "~/Library/Preferences/com.RJMMusicTechnology.MMGTEditor.plist",
-    "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState"
+    "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState",
   ]
 end

--- a/Casks/rjm-mmgteditor.rb
+++ b/Casks/rjm-mmgteditor.rb
@@ -16,6 +16,7 @@ cask "rjm-mmgteditor" do
 
   zap trash: [
     "~/Library/Preferences/com.rjmmusic.MMGTEditor.plist",
-    "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState",
+    "~/Library/Preferences/com.RJMMusicTechnology.MMGTEditor.plist",
+    "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState"
   ]
 end

--- a/Casks/rjm-mmgteditor.rb
+++ b/Casks/rjm-mmgteditor.rb
@@ -1,0 +1,16 @@
+cask "rjm-mmgteditor" do
+  version "4.9.1"
+  sha256 "10e37d4443b107eae1f735a8278fbb06d9776c13ec9626703d02757718086cee"
+
+  url "https://www.rjmmusic.com/downloads/MMGT/MMGTEditor-#{version}.dmg"
+  name "RJM Music Mastermind GT Editor"
+  desc "Editor software to configure RJM Mastermind GT midi pedalboard"
+  homepage "https://www.rjmmusic.com/"
+
+  livecheck do
+    url "https://www.rjmmusic.com/wp-json/wp/v2/pages/6614"
+    regex(/href=.*?MMGTEditor[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
+  app "MMGTEditor.app"
+end

--- a/Casks/rjm-mmgteditor.rb
+++ b/Casks/rjm-mmgteditor.rb
@@ -15,7 +15,7 @@ cask "rjm-mmgteditor" do
   app "MMGTEditor.app"
 
   zap trash: [
-  "~/Library/Preferences/com.rjmmusic.MMGTEditor.plist",
-  "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState",
-]
+    "~/Library/Preferences/com.rjmmusic.MMGTEditor.plist",
+    "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState",
+  ]
 end

--- a/Casks/rjm-mmgteditor.rb
+++ b/Casks/rjm-mmgteditor.rb
@@ -13,4 +13,9 @@ cask "rjm-mmgteditor" do
   end
 
   app "MMGTEditor.app"
+
+  zap trash: [
+  "~/Library/Preferences/com.rjmmusic.MMGTEditor.plist",
+  "~/Library/Saved Application State/com.RJMMusicTechnology.MMGTEditor.savedState",
+]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


This PR is moved from https://github.com/Homebrew/homebrew-cask/pull/136569 because is bad location for the content.

Command used :

```shell
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew audit --cask --online rjm-mmgteditor
==> Downloading https://www.rjmmusic.com/downloads/MMGT/MMGTEditor-4.9.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/763666f0ca1799f5ddc40a4a5e85d5d9e4078d996a7e5c19b46cb942db44dc14--MMGTEditor-4.9.1.dmg
audit for rjm-mmgteditor: passed
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % clear                                    

gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew audit --cask --online rjm-megxeditor
==> Downloading https://www.rjmmusic.com/downloads/MEGX/MEGXEditor-1.1.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/42231c9183f1b1d7ebe9f54161aac5d241e8e823c68e938a0267763ef8548e92--MEGXEditor-1.1.1.dmg
audit for rjm-megxeditor: passed
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew audit --cask --online rjm-mmgteditor
==> Downloading https://www.rjmmusic.com/downloads/MMGT/MMGTEditor-4.9.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/763666f0ca1799f5ddc40a4a5e85d5d9e4078d996a7e5c19b46cb942db44dc14--MMGTEditor-4.9.1.dmg
audit for rjm-mmgteditor: passed
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew style --fix rjm-megxeditor

1 file inspected, no offenses detected
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew style --fix rjm-mmgteditor

1 file inspected, no offenses detected
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew audit --new-cask rjm-megxeditor 
==> Downloading https://www.rjmmusic.com/downloads/MEGX/MEGXEditor-1.1.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/42231c9183f1b1d7ebe9f54161aac5d241e8e823c68e938a0267763ef8548e92--MEGXEditor-1.1.1.dmg
==> Downloading https://www.rjmmusic.com/downloads/MEGX/MEGXEditor-1.1.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/42231c9183f1b1d7ebe9f54161aac5d241e8e823c68e938a0267763ef8548e92--MEGXEditor-1.1.1.dmg
audit for rjm-megxeditor: passed
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew audit --new-cask rjm-mmgteditor
==> Downloading https://www.rjmmusic.com/downloads/MMGT/MMGTEditor-4.9.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/763666f0ca1799f5ddc40a4a5e85d5d9e4078d996a7e5c19b46cb942db44dc14--MMGTEditor-4.9.1.dmg
==> Downloading https://www.rjmmusic.com/downloads/MMGT/MMGTEditor-4.9.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/763666f0ca1799f5ddc40a4a5e85d5d9e4078d996a7e5c19b46cb942db44dc14--MMGTEditor-4.9.1.dmg
audit for rjm-mmgteditor: passed
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew install --cask rjm-megxeditor && brew uninstall --cask rjm-megxeditor
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).

You have 6 outdated formulae installed.
You can upgrade them with brew upgrade
or list them with brew outdated.

==> Downloading https://www.rjmmusic.com/downloads/MEGX/MEGXEditor-1.1.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/42231c9183f1b1d7ebe9f54161aac5d241e8e823c68e938a0267763ef8548e92--MEGXEditor-1.1.1.dmg
==> Installing Cask rjm-megxeditor
==> Moving App 'MEGXEditor.app' to '/Applications/MEGXEditor.app'
🍺  rjm-megxeditor was successfully installed!
Warning: Use python-tabulate instead of deprecated libpython-tabulate
Warning: Use python-tabulate instead of deprecated libpython-tabulate
==> Uninstalling Cask rjm-megxeditor
==> Backing App 'MEGXEditor.app' up to '/opt/homebrew/Caskroom/rjm-megxeditor/1.1.1/MEGXEditor.app'
==> Removing App '/Applications/MEGXEditor.app'
==> Purging files for version 1.1.1 of Cask rjm-megxeditor
gregorydepuille@MBP-de-Gregory homebrew-cask-drivers % brew install --cask rjm-mmgteditor && brew uninstall --cask rjm-mmgteditor
==> Downloading https://www.rjmmusic.com/downloads/MMGT/MMGTEditor-4.9.1.dmg
Already downloaded: /Users/gregorydepuille/Library/Caches/Homebrew/downloads/763666f0ca1799f5ddc40a4a5e85d5d9e4078d996a7e5c19b46cb942db44dc14--MMGTEditor-4.9.1.dmg
==> Installing Cask rjm-mmgteditor
==> Moving App 'MMGTEditor.app' to '/Applications/MMGTEditor.app'
🍺  rjm-mmgteditor was successfully installed!
Warning: Use python-tabulate instead of deprecated libpython-tabulate
Warning: Use python-tabulate instead of deprecated libpython-tabulate
==> Uninstalling Cask rjm-mmgteditor
==> Backing App 'MMGTEditor.app' up to '/opt/homebrew/Caskroom/rjm-mmgteditor/4.9.1/MMGTEditor.app'
==> Removing App '/Applications/MMGTEditor.app'
==> Purging files for version 4.9.1 of Cask rjm-mmgteditor
```