### PR TITLE
Update elecom-mouse-assistant SHA256 checksum

### DIFF
--- a/Casks/elecom-mouse-assistant.rb
+++ b/Casks/elecom-mouse-assistant.rb
@@ -1,6 +1,6 @@
 cask "elecom-mouse-assistant" do
   version "5.2.6.000"
-  sha256 "cba97087fe8f839cd14cd64efd820096cf4e59be1d449a117247ef59c7b695ba"
+  sha256 "c0ea997768f5553b45fca9ae0e20fa9739241117fbf449f1e8769524bd67f200"
 
   url "https://dl.elecom.co.jp/support/download/peripheral/mouse/assistant/mac/ELECOM_Mouse_Installer_#{version}.zip"
   name "ELECOM Mouse Assistant"


### PR DESCRIPTION
**Changes**: Updates the sha-256 for the 'elecom-mouse-assistant' cask. The current value is incorrect and causes an 'SHA mismatch error'. The new value matches that of the file downloaded from the Elecom downloads - https://dl.elecom.co.jp/support/download/peripheral/mouse/assistant/mac/ELECOM_Mouse_Installer_5.2.6.000.zip

_I am unable to run the style-fix as I'm not on my Mac currently. Will update that when I have a chance, but I don't think it should affect it too much as it is only updating an existing value._

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
`audit for elecom-mouse-assistant: passed`
- [ ] `brew style --fix <cask>` reports no offenses.