### PR TITLE
Update rode-central from 1.3.8 to 2.0.14

### DIFF
--- a/Casks/rode-central.rb
+++ b/Casks/rode-central.rb
@@ -1,8 +1,8 @@
 cask "rode-central" do
-  version "1.3.8"
+  version "2.0.14"
   sha256 :no_check
 
-  url "https://cdn1.rode.com/rodecentral_installation_file_mac.zip"
+  url "https://edge.rode.com/zip/page/1873/modules/4782/RODE-Central_MACOS%20(#{version}).zip"
   name "Rode Central"
   desc "Configure RØDE device settings, features, functions, and firmware"
   homepage "https://rode.com/software/rode-central"
@@ -14,7 +14,7 @@ cask "rode-central" do
 
   depends_on macos: ">= :high_sierra"
 
-  pkg "RODE Central v#{version}_macOS/RODE Central Installer.pkg"
+  pkg "RODE-Central_MACOS (#{version})/RODE Central Installer (#{version}).pkg"
 
   uninstall pkgutil: "com.rodecentral.installer"
 end


### PR DESCRIPTION
Update rode-central to the latest stable version on the website at the moment ([2.0.14](https://rode.com/it/software/rode-central#module_22)).

The previous formats of the URL and the pkg are not working anymore, so I changed them to the new ones using the version as a parameter - this should allow smoother updates of the cask by only changing the version.

-----


_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
