### PR TITLE
Fix URL of nordic-nrf-command-line-tools

### DIFF
--- a/Casks/nordic-nrf-command-line-tools.rb
+++ b/Casks/nordic-nrf-command-line-tools.rb
@@ -2,7 +2,7 @@ cask "nordic-nrf-command-line-tools" do
   version "10.18.1"
   sha256 "e060ddf2044677f08c4f825ee31dfc8525c26f557abcb700758e1193bc556c9f"
 
-  url "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-#{version.major}-x-x/#{version.dots_to_hyphens}/nrf-command-line-tools-#{version}-darwin.dmg"
+  url "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-#{version.major}-x-x/#{version.dots_to_hyphens}/nrf-command-line-tools-#{version}-darwin.dmg", verified: "nsscprodmedia.blob.core.windows.net/"
   name "nRF Command Line Tools"
   desc "Command-line tools for Nordic nRF Semiconductors"
   homepage "https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools"

--- a/Casks/nordic-nrf-command-line-tools.rb
+++ b/Casks/nordic-nrf-command-line-tools.rb
@@ -2,7 +2,7 @@ cask "nordic-nrf-command-line-tools" do
   version "10.18.1"
   sha256 "e060ddf2044677f08c4f825ee31dfc8525c26f557abcb700758e1193bc556c9f"
 
-  url "https://www.nordicsemi.com/-/media/Software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/Versions-#{version.major}-x-x/#{version.dots_to_hyphens}/nrf-command-line-tools-#{version}-darwin.dmg"
+  url "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-#{version.major}-x-x/#{version.dots_to_hyphens}/nrf-command-line-tools-#{version}-darwin.dmg"
   name "nRF Command Line Tools"
   desc "Command-line tools for Nordic nRF Semiconductors"
   homepage "https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online nordic-nrf-command-line-tools` is error-free.
- [x] `brew style --fix nordic-nrf-command-line-tools` reports no offenses.
