### PR TITLE
Update tomtom-mydrive-connect from 4.2.12.4441 to 4.2.13.4586

### DIFF
--- a/Casks/tomtom-mydrive-connect.rb
+++ b/Casks/tomtom-mydrive-connect.rb
@@ -1,18 +1,20 @@
 cask "tomtom-mydrive-connect" do
-  version "4.2.12.4441"
-  sha256 "ab0989241a1c67012cc64edfc6658b10420f0e888eb3e9ff65b4b08b4435db14"
+  version "4.2.13.4586"
+  sha256 :no_check
 
-  url "https://cdn.sa.services.tomtom.com/static/sa/versions/MyDriveConnect_mac_#{version.dots_to_underscores}.zip"
+  url "https://cdn.sa.services.tomtom.com/static/sa/Mac/TomTomMyDriveConnect.dmg"
   name "TomTom MyDrive Connect"
   desc "Update your TomTom navigation device"
   homepage "https://www.tomtom.com/mydrive-connect/"
 
-  livecheck do
-    url "https://help.tomtom.com/hc/en-us/articles/360014400719-MyDrive-Connect"
-    regex(/Version:\s*(\d+(?:\.\d+)+)\s*OS:\s*mac/i)
-  end
+  # Technically, TomTom publishes release information as described below, however,
+  # the page has not been updated since 2021-10-13 for macOS
+  # livecheck do
+  #  url "https://help.tomtom.com/hc/en-us/articles/360014400719-MyDrive-Connect"
+  #  regex(/Version:\s*(\d+(?:\.\d+)+)\s*OS:\s*mac/i)
+  # end
 
-  pkg "MyDriveConnect_mac_#{version.dots_to_underscores}.mpkg"
+  pkg "MyDriveConnect.mpkg"
 
   uninstall quit:       [
               "com.tomtom.mytomtomsa",

--- a/Casks/tomtom-mydrive-connect.rb
+++ b/Casks/tomtom-mydrive-connect.rb
@@ -7,12 +7,9 @@ cask "tomtom-mydrive-connect" do
   desc "Update your TomTom navigation device"
   homepage "https://www.tomtom.com/mydrive-connect/"
 
-  # Technically, TomTom publishes release information as described below, however,
-  # the page has not been updated since 2021-10-13 for macOS
-  # livecheck do
-  #  url "https://help.tomtom.com/hc/en-us/articles/360014400719-MyDrive-Connect"
-  #  regex(/Version:\s*(\d+(?:\.\d+)+)\s*OS:\s*mac/i)
-  # end
+  livecheck do
+    skip "No reliable way to get version info"
+  end
 
   pkg "MyDriveConnect.mpkg"
 


### PR DESCRIPTION
- Split the cask definition according to the officially supported macOS version <=10.9 and >=10.10 described here: https://help.tomtom.com/hc/en-us/articles/360013959499
- Point download URLs at current URLs provided by TomTom.
- Remove livecheck for modern versions because TomTom does not publish the version information for macOS anymore (last documented update on 2021-10-13) even though newer versions exist.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
