### PR TITLE
Bumping wacom-tablet to 6.4.0-9

### DIFF
--- a/Casks/wacom-tablet.rb
+++ b/Casks/wacom-tablet.rb
@@ -1,6 +1,6 @@
 cask "wacom-tablet" do
-  version "6.3.46-2"
-  sha256 "cd3f1134d721139f93f809039a0238c248412730cc20489dfe588f9080ea82b0"
+  version "6.4.0-9"
+  sha256 "a193904ebf2d1b35a39794e23a622054b1d0957bf292c07e8ec356379e12bfe3"
 
   url "https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   name "Wacom Tablet"


### PR DESCRIPTION
Bumps wacom-tablet to 6.4.0-9.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
