### PR TITLE
brother-p-touch-update-software: convert to `on_system` blocks

### DIFF
--- a/Casks/brother-p-touch-update-software.rb
+++ b/Casks/brother-p-touch-update-software.rb
@@ -1,27 +1,36 @@
 cask "brother-p-touch-update-software" do
-  os = {
-    high_sierra: "10046",
-    mojave:      "10051",
-    catalina:    "10057",
-    big_sur:     "10064",
-    monterey:    "10071",
-  }
-
-  if MacOS.version <= :catalina
-    version "1.5.5,15,100785"
+  on_high_sierra :or_older do
+    version "1.5.5,15,100785,10046"
     sha256 "c6e1afdb1daf04c143532f9dab019a764a2f6e07567c1b42d61d34232b990c32"
-  else
-    version "1.5.6,110,100885"
+  end
+  on_mojave do
+    version "1.5.5,15,100785,10051"
+    sha256 "c6e1afdb1daf04c143532f9dab019a764a2f6e07567c1b42d61d34232b990c32"
+  end
+  on_catalina do
+    version "1.5.5,15,100785,10057"
+    sha256 "c6e1afdb1daf04c143532f9dab019a764a2f6e07567c1b42d61d34232b990c32"
+  end
+  on_big_sur do
+    version "1.5.6,110,100885,10064"
+    sha256 "179cd72961d1f2b8fba1146a4b636ca1529e8fc8adecac0165111ac36bd85a7a"
+  end
+  on_monterey do
+    version "1.5.6,110,100885,10071"
+    sha256 "179cd72961d1f2b8fba1146a4b636ca1529e8fc8adecac0165111ac36bd85a7a"
+  end
+  on_ventura :or_newer do
+    version "1.5.6,110,100885,10078"
     sha256 "179cd72961d1f2b8fba1146a4b636ca1529e8fc8adecac0165111ac36bd85a7a"
   end
 
-  url "https://download.brother.com/welcome/dlfp#{version.csv[2]}/pum#{version.csv[0].no_dots}x#{version.csv[1]}all.dmg"
+  url "https://download.brother.com/welcome/dlfp#{version.csv.third}/pum#{version.csv.first.no_dots}x#{version.csv.second}all.dmg"
   name "Brother P-touch Update Software"
   desc "Software for Brother P-touch label printers"
   homepage "https://support.brother.com/"
 
   livecheck do
-    url "https://support.brother.com/g/b/downloadlist.aspx?c=nz&lang=en&prod=d800weas&os=#{os[MacOS.version.to_sym]}"
+    url "https://support.brother.com/g/b/downloadlist.aspx?c=nz&lang=en&prod=d800weas&os=#{version.csv[3]}"
     strategy :page_match do |page|
       download_match = page.match(/href=["']?([^"' >]*?)["']?>P-touch Update Software \(Mac\)</i)
       next if download_match.blank?
@@ -38,11 +47,11 @@ cask "brother-p-touch-update-software" do
       next if dlfp_match.blank?
       next if dlfp_match[2] != version_match[1].tr(".", "")
 
-      "#{version_match[1]},#{dlfp_match[3]},#{dlfp_match[1]}"
+      "#{version_match[1]},#{dlfp_match[3]},#{dlfp_match[1]},#{version.csv[3]}"
     end
   end
 
-  depends_on macos: os.keys
+  depends_on macos: ">= :high_sierra"
 
   pkg "BrotherPtUpdateSoftware.pkg"
 


### PR DESCRIPTION
cc: @Rylan12 - would love your thoughts on this one. We can't pass variables from an `on_system` block into livecheck so couldn't assign a named variable here, so included the required string part in the versions for now.