### PR TITLE
Bump synology-photo-station-uploader from 1.4.5 to 1.4.6

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -10,7 +10,7 @@ cask "synology-photo-station-uploader" do
   livecheck do
     url "https://www.synology.com/en-us/releaseNote/PhotoStationUploader"
     strategy :patch_match do |page|
-      match = page.match(/<h3>Version:\s(\d+(?:\.\d+)+)\-(\d+)/i)
+      match = page.match(/<h3>Version:\s(\d+(?:\.\d+)+)-(\d+)/i)
 
       "#{match[1]},#{match[2]}"
     end

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,8 +1,8 @@
 cask "synology-photo-station-uploader" do
-  version "1.4.5,093"
-  sha256 "16191318254ad221f52fa1c2b6ed1509d9cc22349c3129935f717fca7f0d44f1"
+  version "1.4.6,098"
+  sha256 "6969aa9d75e8b8a57e64db6ff81e9fc8826c5a08432ccea7713b589cad9f7895"
 
-  url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version.csv.first}-#{version.csv.second}/Mac/SynologyPhotoStationUploader-#{version.csv.second}-Mac-Installer.dmg"
+  url "https://global.download.synology.com/download/Utility/PhotoStationUploader/#{version.csv.first}-#{version.csv.second}/Mac/SynologyPhotoStationUploader-#{version.csv.second}-Mac-Installer.dmg"
   appcast "https://www.synology.com/en-us/releaseNote/PhotoStationUploader"
   name "Synology Photo Station Uploader"
   desc "Bulk upload photos and videos to Synology Photo Station"
@@ -10,11 +10,15 @@ cask "synology-photo-station-uploader" do
 
   pkg "SynologyPhotoStationUploader-#{version.after_comma}-Mac-Installer.pkg"
 
-  uninstall pkgutil:   "com.synology.photostationuploader.installer",
+  uninstall pkgutil:   [
+              "com.synology.photostationuploader.installer",
+              "inc.synology.photostationuploader",
+            ],
             quit:      "com.synology.PhotoStationUploader",
             launchctl: [
               "com.synology.PhotoUploaderFinderSync",
               "com.synology.PhotoUploaderShellApp",
+              "com.synology.PhotoUploaderUninstaller",
               "com.synology.SynoSIMBL_RefreshFinder",
             ]
 end

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -3,10 +3,18 @@ cask "synology-photo-station-uploader" do
   sha256 "6969aa9d75e8b8a57e64db6ff81e9fc8826c5a08432ccea7713b589cad9f7895"
 
   url "https://global.download.synology.com/download/Utility/PhotoStationUploader/#{version.csv.first}-#{version.csv.second}/Mac/SynologyPhotoStationUploader-#{version.csv.second}-Mac-Installer.dmg"
-  appcast "https://www.synology.com/en-us/releaseNote/PhotoStationUploader"
   name "Synology Photo Station Uploader"
   desc "Bulk upload photos and videos to Synology Photo Station"
   homepage "https://www.synology.com/"
+
+  livecheck do
+    url "https://www.synology.com/en-us/releaseNote/PhotoStationUploader"
+    strategy :patch_match do |page|
+      match = page.match(/<h3>Version:\s(\d+(?:\.\d+)+)\-(\d+)/i)
+
+      "#{match[1]},#{match[2]}"
+    end
+  end
 
   pkg "SynologyPhotoStationUploader-#{version.after_comma}-Mac-Installer.pkg"
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
