### PR TITLE
Make usage commands easily copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Casks of drivers
 After you install Homebrew, run the following command:
 
 ```sh
-$ brew tap homebrew/cask-drivers
+brew tap homebrew/cask-drivers
 ```
 
 You can now install the casks in this repo.
 
 ```sh
-$ brew install xbox360-controller-driver-unofficial
+brew install xbox360-controller-driver-unofficial
 ```
 
 ## Submitting a Cask to this repository


### PR DESCRIPTION
GitHub now automatically adds a “copy” button to rendered docs when hovering over a code block.

Having the shell prompt indicator `$` means these commands cannot easily be used with this functionality.

Removing them makes things a little easier to use!