### PR TITLE
Add Logi Tune cask

### DIFF
--- a/Casks/logi-tune.rb
+++ b/Casks/logi-tune.rb
@@ -1,0 +1,29 @@
+cask "logi-tune" do
+  version "3.0.180"
+  sha256 "1df55f7240aff2ab107ee4b35291a12c01b4be2a46cd0f938c87254d7fce4a94"
+
+  url "https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg",
+      verified: "software.vc.logitech.com/downloads/tune/"
+  name "Logi Tune"
+  desc "Optimize your webcam, headset, and Logi Dock for video meetings"
+  homepage "https://www.logitech.com/en-us/video-collaboration/software/logi-tune-software.html"
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  installer manual: "LogiTuneInstaller.app"
+
+  uninstall delete: [
+    "/Applications/LogiTune.app",
+    "/Library/LaunchAgents/com.logitech.logitune.launcher.plist",
+    "/Library/LaunchDaemons/com.logitech.LogiRightSight.plist",
+  ]
+
+  zap trash: [
+    "/Users/Shared/logitune",
+    "/Users/Shared/LogiTuneInstallerStarted.txt",
+    "~/Library/Application Support/logitune",
+    "~/Library/Preferences/com.logitech.logitune.plist",
+    "~/Library/Saved Application State/com.logitech.logituneInstaller.savedState",
+  ]
+end

--- a/Casks/logitune.rb
+++ b/Casks/logitune.rb
@@ -7,6 +7,11 @@ cask "logitune" do
   desc "Optimize your webcam, headset, and Logi Dock for video meetings"
   homepage "https://www.logitech.com/en-us/video-collaboration/software/logi-tune-software.html"
 
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
   auto_updates true
   depends_on macos: ">= :catalina"
 

--- a/Casks/logitune.rb
+++ b/Casks/logitune.rb
@@ -1,10 +1,9 @@
-cask "logi-tune" do
+cask "logitune" do
   version "3.0.180"
-  sha256 "1df55f7240aff2ab107ee4b35291a12c01b4be2a46cd0f938c87254d7fce4a94"
+  sha256 :no_check
 
-  url "https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg",
-      verified: "software.vc.logitech.com/downloads/tune/"
-  name "Logi Tune"
+  url "https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
+  name "LogiTune"
   desc "Optimize your webcam, headset, and Logi Dock for video meetings"
   homepage "https://www.logitech.com/en-us/video-collaboration/software/logi-tune-software.html"
 


### PR DESCRIPTION
This PR adds the [LogiTune](https://www.logitech.com/en-us/video-collaboration/software/logi-tune-software.html) application as a driver cask.  This is my first time contributing to Homebrew, so hopefully I did it correctly 🙂 

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
