### PR TITLE
rubocop: Fix `Cask/StanzaOrder` offenses for `on_*` blocks

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -1,4 +1,6 @@
 cask "asix-ax88179" do
+  sha256 :no_check
+
   on_mojave :or_older do
     version "2.19.0,1242"
 
@@ -31,6 +33,18 @@ cask "asix-ax88179" do
       end
     end
   end
+  on_catalina :or_older do
+    uninstall_preflight do
+      staged_path.glob("AX88179_178A_Uninstall_v*.pkg").first.rename(staged_path/"AX88179_178A_Uninstall.pkg")
+
+      system_command "/usr/sbin/installer",
+                     args: [
+                       "-pkg", staged_path/"AX88179_178A_Uninstall.pkg",
+                       "-target", "/"
+                     ],
+                     sudo: true
+    end
+  end
   on_big_sur do
     version "1.3.0,1301"
 
@@ -45,6 +59,18 @@ cask "asix-ax88179" do
           list_item.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
         end.flatten
       end
+    end
+  end
+  on_big_sur :or_newer do
+    uninstall_preflight do
+      staged_path.glob("ASIX_USB_Device_Un*.pkg").first.rename(staged_path/"AX88179_178A_Uninstall.pkg")
+
+      system_command "/usr/sbin/installer",
+                     args: [
+                       "-pkg", staged_path/"AX88179_178A_Uninstall.pkg",
+                       "-target", "/"
+                     ],
+                     sudo: true
     end
   end
   on_monterey :or_newer do
@@ -64,37 +90,10 @@ cask "asix-ax88179" do
     end
   end
 
-  sha256 :no_check
-
   url "https://www.asix.com.tw/en/support/download/file/#{version.csv.second}"
   name "AX88179"
   desc "USB 3.0 to gigabit ethernet drivers for ASIX Electronics devices"
   homepage "https://www.asix.com.tw/en/support/download"
-
-  on_catalina :or_older do
-    uninstall_preflight do
-      staged_path.glob("AX88179_178A_Uninstall_v*.pkg").first.rename(staged_path/"AX88179_178A_Uninstall.pkg")
-
-      system_command "/usr/sbin/installer",
-                     args: [
-                       "-pkg", staged_path/"AX88179_178A_Uninstall.pkg",
-                       "-target", "/"
-                     ],
-                     sudo: true
-    end
-  end
-  on_big_sur :or_newer do
-    uninstall_preflight do
-      staged_path.glob("ASIX_USB_Device_Un*.pkg").first.rename(staged_path/"AX88179_178A_Uninstall.pkg")
-
-      system_command "/usr/sbin/installer",
-                     args: [
-                       "-pkg", staged_path/"AX88179_178A_Uninstall.pkg",
-                       "-target", "/"
-                     ],
-                     sudo: true
-    end
-  end
 
   uninstall pkgutil: [
     "com.asix.ax88179.uninstall",

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -2,33 +2,42 @@ cask "displaylink" do
   on_sierra :or_older do
     version "4.3.1,2021-02"
     sha256 "d5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97"
+
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20Mac%20OS%20X%20and%20macOS#{version.csv.first}-EXE.dmg"
+
+    pkg "DisplayLink Software Installer.pkg"
   end
   on_high_sierra do
     version "5.1.1,2021-02"
     sha256 "1ac9093f8113af8c35d6f3ff5b1ae3f119a5aff0d5309d75c7a1742f159184b5"
+
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
+
+    pkg "DisplayLink Software Installer.pkg"
   end
   on_mojave do
     version "5.2.6,2021-05"
     sha256 "9f1854cd5720105d6d45c91172419c503358543e4a23d7113387aedf16a39cbb"
+
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
-  end
-  on_mojave :or_older do
+
     pkg "DisplayLink Software Installer.pkg"
   end
   on_catalina do
     version "1.5,2021-09"
     sha256 "d703cc8e9093e4d163c5e612326c0907a02c6d4eec6aaca8d0727503859ef95d"
+
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
-  end
-  on_catalina :or_newer do
+
     pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
   end
   on_big_sur :or_newer do
     version "1.8.1,2023-03"
     sha256 "5b8ab02a2c205d9592aa3e4aa40d37223092d7db2b2d92d1ad42b275b9d159fe"
+
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
+
+    pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
   end
 
   name "DisplayLink USB Graphics Software"
@@ -42,8 +51,8 @@ cask "displaylink" do
   uninstall pkgutil:   "com.displaylink.*",
             # 'kextunload -b com.displaylink.driver.DisplayLinkDriver' causes kernel panic
             # kext:      [
-            #              'com.displaylink.driver.DisplayLinkDriver',
             #              'com.displaylink.dlusbncm'
+            #              'com.displaylink.driver.DisplayLinkDriver',
             #            ],
             launchctl: [
               "73YQY62QM3.com.displaylink.DisplayLinkAPServer",

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -14,10 +14,16 @@ cask "displaylink" do
     sha256 "9f1854cd5720105d6d45c91172419c503358543e4a23d7113387aedf16a39cbb"
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
   end
+  on_mojave :or_older do
+    pkg "DisplayLink Software Installer.pkg"
+  end
   on_catalina do
     version "1.5,2021-09"
     sha256 "d703cc8e9093e4d163c5e612326c0907a02c6d4eec6aaca8d0727503859ef95d"
     url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
+  end
+  on_catalina :or_newer do
+    pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
   end
   on_big_sur :or_newer do
     version "1.8.1,2023-03"
@@ -31,13 +37,6 @@ cask "displaylink" do
 
   livecheck do
     skip "No version information available"
-  end
-
-  on_mojave :or_older do
-    pkg "DisplayLink Software Installer.pkg"
-  end
-  on_catalina :or_newer do
-    pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
   end
 
   uninstall pkgutil:   "com.displaylink.*",

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -4,12 +4,16 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
     sha256 :no_check
 
     url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=08e8308b1e134d6bb6837e3b046b126b&tx_kmanacondaimport_downloadproxy[documentId]=122431&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
+
+    pkg "C759_C658_C368_C287_C3851_Series_v#{version}_Letter/C759_C658_C368_C287_C3851.pkg"
   end
   on_big_sur :or_newer do
     version "11.8.0A"
     sha256 :no_check
 
     url "https://dl.konicaminolta.eu/en?tx_kmanacondaimport_downloadproxy[fileId]=7228bd01e7674417c6a223ce7a186487&tx_kmanacondaimport_downloadproxy[documentId]=130160&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
+
+    pkg "C759_C658_C368_C287_C3851_#{version.major}.pkg"
   end
 
   name "KONICA MINOLTA bizhub C759/C658/C368/C287/C3851 Series Printer"
@@ -21,13 +25,6 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
   end
 
   depends_on macos: ">= :sierra"
-
-  on_catalina :or_older do
-    pkg "C759_C658_C368_C287_C3851_Series_v#{version}_Letter/C759_C658_C368_C287_C3851.pkg"
-  end
-  on_big_sur :or_newer do
-    pkg "C759_C658_C368_C287_C3851_#{version.major}.pkg"
-  end
 
   uninstall pkgutil: "jp.konicaminolta.print.package.C759"
 end

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -3,7 +3,7 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
     version "11.6.0"
     sha256 :no_check
 
-    url "https://dl.konicaminolta.eu/en/?tx_kmanacondaimport_downloadproxy[fileId]=08e8308b1e134d6bb6837e3b046b126b&tx_kmanacondaimport_downloadproxy[documentId]=122431&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
+    url "https://dl.konicaminolta.eu/en?tx_kmdownloadcentersite_downloadproxy[fileId]=08e8308b1e134d6bb6837e3b046b126b&tx_kmdownloadcentersite_downloadproxy[documentId]=122431&tx_kmdownloadcentersite_downloadproxy[system]=KonicaMinolta&tx_kmdownloadcentersite_downloadproxy[language]=EN&type=1558521685"
 
     pkg "C759_C658_C368_C287_C3851_Series_v#{version}_Letter/C759_C658_C368_C287_C3851.pkg"
   end
@@ -11,7 +11,7 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
     version "11.8.0A"
     sha256 :no_check
 
-    url "https://dl.konicaminolta.eu/en?tx_kmanacondaimport_downloadproxy[fileId]=7228bd01e7674417c6a223ce7a186487&tx_kmanacondaimport_downloadproxy[documentId]=130160&tx_kmanacondaimport_downloadproxy[system]=KonicaMinolta&tx_kmanacondaimport_downloadproxy[language]=EN&type=1558521685"
+    url "https://dl.konicaminolta.eu/en?tx_kmdownloadcentersite_downloadproxy[fileId]=7228bd01e7674417c6a223ce7a186487&tx_kmdownloadcentersite_downloadproxy[documentId]=130160&tx_kmdownloadcentersite_downloadproxy[system]=KonicaMinolta&tx_kmdownloadcentersite_downloadproxy[language]=EN&type=1558521685"
 
     pkg "C759_C658_C368_C287_C3851_#{version.major}.pkg"
   end

--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -6,6 +6,8 @@ cask "logitech-options" do
     url "https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
         verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
 
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
+
     livecheck do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.12"
       regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
@@ -18,13 +20,12 @@ cask "logitech-options" do
     url "https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
         verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
 
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
+
     livecheck do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.13"
       regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
     end
-  end
-  on_high_sierra :or_older do
-    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
   end
   on_mojave do
     version "8.54.147"
@@ -33,13 +34,12 @@ cask "logitech-options" do
     url "https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
         verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
 
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
+
     livecheck do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.14"
       regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
     end
-  end
-  on_mojave :or_newer do
-    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
   end
   on_catalina :or_newer do
     version "10.00.75"
@@ -47,6 +47,8 @@ cask "logitech-options" do
 
     url "https://download01.logi.com/web/ftp/pub/techsupport/options/options_installer.zip",
         verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
+
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
 
     livecheck do
       url "https://download01.logi.com/web/ftp/pub/techsupport/options/options_installer.zip"

--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -23,6 +23,9 @@ cask "logitech-options" do
       regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
     end
   end
+  on_high_sierra :or_older do
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
+  end
   on_mojave do
     version "8.54.147"
     sha256 "7b7a8d7a498d868c90b4ffe7dfc50a7a39c25e1f61350702e87d4c771b3d6459"
@@ -34,6 +37,9 @@ cask "logitech-options" do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.14"
       regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
     end
+  end
+  on_mojave :or_newer do
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
   end
   on_catalina :or_newer do
     version "10.00.75"
@@ -54,13 +60,6 @@ cask "logitech-options" do
 
   auto_updates true
   depends_on macos: ">= :sierra"
-
-  on_high_sierra :or_older do
-    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
-  end
-  on_mojave :or_newer do
-    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
-  end
 
   uninstall launchctl: [
               "com.logi.bolt.app",

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -60,8 +60,8 @@ cask "xerox-print-driver" do
     pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
   end
   on_big_sur :or_newer do
-    version "5.11.2_2379"
-    sha256 "787f906a31b6d91150733a7b4ca104696cd5a7d3887e35db647f8762f626b8a5"
+    version "5.12.1_2403"
+    sha256 "696ee196543de04c636e80e62c652851dbffe7b2d0d8b35484d92a26ba00d02d"
 
     url "https://download.support.xerox.com/pub/drivers/ALB80XX/drivers/macOSx11/pt_BR/XeroxDrivers_#{version}.dmg"
 

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -17,6 +17,9 @@ cask "xerox-print-driver" do
       skip "Legacy version"
     end
   end
+  on_sierra :or_older do
+    pkg "Xerox Print Driver #{version.sub(/_.*/, "")}.pkg"
+  end
   on_high_sierra do
     version "5.6.0_2187"
     sha256 "562143dcd8fda5df84d9cdc39e09f242898e40d63866c596632d7cd7f7c85844"
@@ -25,6 +28,9 @@ cask "xerox-print-driver" do
     livecheck do
       skip "Legacy version"
     end
+  end
+  on_high_sierra :or_newer do
+    pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
   end
   on_mojave do
     version "5.8.0_2275"
@@ -58,13 +64,6 @@ cask "xerox-print-driver" do
   name "Xerox Print Driver"
   desc "Drivers for Xerox printers"
   homepage "https://www.support.xerox.com/en-us/product/phaser-6510/downloads"
-
-  on_sierra :or_older do
-    pkg "Xerox Print Driver #{version.sub(/_.*/, "")}.pkg"
-  end
-  on_high_sierra :or_newer do
-    pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
-  end
 
   uninstall launchctl: [
               "com.aviatainc.powerengage.helper.XRTK",

--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -2,63 +2,75 @@ cask "xerox-print-driver" do
   on_el_capitan :or_older do
     version "4.17.1_1980"
     sha256 "36b1ddf1f598ceaf6f91d38b0d228be3f8f6188c251761424cbea7a869488883"
+
     url "https://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1011/pt_BR/XeroxPrintDriver_#{version}.dmg"
 
     livecheck do
       skip "Legacy version"
     end
+
+    pkg "Xerox Print Driver #{version.sub(/_.*/, "")}.pkg"
   end
   on_sierra do
     version "5.2.0_2115"
     sha256 "9989b6c127fca8c97b24bd86fd4d20035cd094c69e3fd41f6a243361f86483ec"
+
     url "https://download.support.xerox.com/pub/drivers/CQ8570/drivers/macos1012/pt_BR/XeroxPrintDriver_#{version}.dmg"
 
     livecheck do
       skip "Legacy version"
     end
-  end
-  on_sierra :or_older do
+
     pkg "Xerox Print Driver #{version.sub(/_.*/, "")}.pkg"
   end
   on_high_sierra do
     version "5.6.0_2187"
     sha256 "562143dcd8fda5df84d9cdc39e09f242898e40d63866c596632d7cd7f7c85844"
+
     url "https://download.support.xerox.com/pub/drivers/BALTORO_HF/drivers/macOS10_13/pt_BR/XeroxDrivers_#{version}.dmg"
 
     livecheck do
       skip "Legacy version"
     end
-  end
-  on_high_sierra :or_newer do
+
     pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
   end
   on_mojave do
     version "5.8.0_2275"
     sha256 "8934306cb5d2322e0cd6e058a4634edbd9c9392aa83364ed5859fb3941516b27"
+
     url "https://download.support.xerox.com/pub/drivers/ALB80XX/drivers/macOS10_13/pt_BR/XeroxDrivers_#{version}.dmg"
 
     livecheck do
       skip "Legacy version"
     end
+
+    pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
   end
   on_catalina do
     version "5.10.1_2333"
     sha256 "c8d4ca41d939aee275831eeebcd0d84aa2f219e24d4100c63ef0b78110fe7680"
+
     url "https://download.support.xerox.com/pub/drivers/ALB80XX/drivers/macOS10_15/pt_BR/XeroxDrivers_#{version}.dmg"
 
     livecheck do
       skip "Legacy version"
     end
+
+    pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
   end
   on_big_sur :or_newer do
     version "5.11.2_2379"
     sha256 "787f906a31b6d91150733a7b4ca104696cd5a7d3887e35db647f8762f626b8a5"
+
     url "https://download.support.xerox.com/pub/drivers/ALB80XX/drivers/macOSx11/pt_BR/XeroxDrivers_#{version}.dmg"
 
     livecheck do
       url :homepage
       regex(/XeroxDrivers[._-](\d+(?:\.\d+)*_\d+)\.dmg/i)
     end
+
+    pkg "Xerox Drivers #{version.sub(/_.*/, "")}.pkg"
   end
 
   name "Xerox Print Driver"


### PR DESCRIPTION
Fixes new RuboCop offenses from https://github.com/Homebrew/brew/pull/14976.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
