### PR TITLE
logi-options-plus: use installer script for automated install and uninstall

### DIFF
--- a/Casks/logi-options-plus.rb
+++ b/Casks/logi-options-plus.rb
@@ -18,9 +18,19 @@ cask "logi-options-plus" do
   auto_updates true
   depends_on macos: ">= :catalina"
 
-  installer manual: "logioptionsplus_installer.app"
+  # see https://prosupport.logi.com/hc/en-us/articles/6046882446359
+  installer script: {
+    executable: "logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer",
+    args:       ["--quiet"],
+    sudo:       true,
+  }
 
-  uninstall launchctl: [
+  uninstall script:    [
+              executable: "logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer",
+              args:       ["--quiet", "--uninstall"],
+              sudo:       true,
+            ],
+            launchctl: [
               "com.logi.cp-dev-mgr",
               "com.logi.optionsplus",
               "com.logi.optionsplus.agent",


### PR DESCRIPTION
This uses the instructions from 
[Mass installation and configuration of Logitech Options+ software](https://prosupport.logi.com/hc/en-us/articles/6046882446359) to launch installer on install and uninstall and allow automated install and upgrade.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.


