### PR TITLE
Bump lg-onscreen-control.rb to 5.98

### DIFF
--- a/Casks/lg-onscreen-control.rb
+++ b/Casks/lg-onscreen-control.rb
@@ -1,6 +1,6 @@
 cask "lg-onscreen-control" do
-  version "5.77,EnFwN1QXofikcxbjmkodXw"
-  sha256 "3ca394ca928f6811b52a21a2953c0531f46a1decc188cb41be859b589c3fdee3"
+  version "5.98,UHgt90CKZsyWb6QbRnjUDQ"
+  sha256 "91b28b4259f4f79428dfa997b7b5f8c31bd30ebf458e2299a9c72b25c6e186a7"
 
   url "https://gscs-b2c.lge.com/downloadFile?fileId=#{version.csv.second}",
       verified: "lge.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


-----

Release notes from 

```text
[Mac OS] OnScreen Control - version 5.98
OnScreen Control is an application used to manage a single monitor or a group of monitor with useful features such as Monitor Control, My Display Presets and Screen Split. OnScreen Control displays all connected LG monitor information. This software is compatible with LG monitors only.

Note:
- OnScreen Control can support up to 4 monitors.
- Depending on the connected monitor, supported menu may vary.

Version : 5.98

Supported OS : macOS 12, macOS 13

*Note: The Monitor Software Update feature of the OnScreen Control is not supported for following models from 1st June 2021.

      - 38WK95C,  27UK670, 27BK67U,  32GK850F, 32UK750, 27GL850, 27QN880, 34GN850, 
        35WN75C, 35BN75C,  35WN73A, 27UK670, 24QP750, 34GN73A,  32GP850,  27GP850, 
        34WP85C, 34WP88C, 32UP55, 35WN75CN

```
