### PR TITLE
rubocop: Fix `Cask/StanzaGrouping` offenses in `on_*` blocks

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -5,6 +5,7 @@ cask "asix-ax88179" do
     version "2.19.0,1242"
 
     container nested: "AX88179_178A_macOS_10.9_to_10.15_Driver_Installer_v#{version.csv.first}_20220517/AX88179_178A_v#{version.csv.first}.dmg"
+
     pkg ".AX88179_178A_10.9_10.14.pkg"
 
     livecheck do
@@ -21,6 +22,7 @@ cask "asix-ax88179" do
     version "2.19.0,1242"
 
     container nested: "AX88179_178A_macOS_10.9_to_10.15_Driver_Installer_v#{version.csv.first}_20220517/AX88179_178A_v#{version.csv.first}.dmg"
+
     pkg ".AX88179_178A_10.15.pkg"
 
     livecheck do
@@ -49,6 +51,7 @@ cask "asix-ax88179" do
     version "1.3.0,1301"
 
     container nested: "ASIX_USB_Device_Installer_macOS_11.3_to11.6_Driver_v#{version.csv.first}_20220706/ASIX_USB_Device_Installer_v#{version.csv.first}.dmg"
+
     pkg "ASIX_USB_Device_Installer_v#{version.csv.first}.pkg"
 
     livecheck do
@@ -77,6 +80,7 @@ cask "asix-ax88179" do
     version "2.3.0,1372"
 
     container nested: "ASIX_USB_Device_Installer_macOS_12_above_Driver_v#{version.csv.first}/ASIX_USB_Device_Installer_v#{version.csv.first}.dmg"
+
     pkg "ASIX_USB_Device_Installer_v#{version.csv.first}.pkg"
 
     livecheck do

--- a/Casks/nvidia-cuda-toolkit.rb
+++ b/Casks/nvidia-cuda-toolkit.rb
@@ -2,11 +2,13 @@ cask "nvidia-cuda-toolkit" do
   on_sierra :or_older do
     version "9.0.176"
     sha256 "8fad950098337d2611d64617ca9f62c319d97c5e882b8368ed196e994bdaf225"
+
     url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
   end
   on_high_sierra :or_newer do
     version "10.1.243"
     sha256 "432a2f07a793f21320edc5d10e7f68a8e4e89465c31e1696290bdb0ca7c8c997"
+
     url "https://developer.download.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac.dmg"
   end
 

--- a/Casks/roland-quad-capture-usb-driver.rb
+++ b/Casks/roland-quad-capture-usb-driver.rb
@@ -2,6 +2,7 @@ cask "roland-quad-capture-usb-driver" do
   on_sierra :or_older do
     version "1.5.3,12"
     sha256 "712b27a25275d748e35c174b242f21a2967f5caca013f6cb09330b9232288770"
+
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
     pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
@@ -9,6 +10,7 @@ cask "roland-quad-capture-usb-driver" do
   on_high_sierra do
     version "1.5.4,13"
     sha256 "d3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117"
+
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
     pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
@@ -16,6 +18,7 @@ cask "roland-quad-capture-usb-driver" do
   on_mojave do
     version "1.5.4,13"
     sha256 "d3524d7844d24805c3a1c25c09dce62ab87d4c8dd6941a0b1d3653c696563117"
+
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
     pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
@@ -23,6 +26,7 @@ cask "roland-quad-capture-usb-driver" do
   on_catalina do
     version "1.5.5,15"
     sha256 "fce600fdbd50b50d69a676700ef42ee038db50d201874dadf3c0e1ac291df23f"
+
     url "https://static.roland.com/assets/media/tgz/quad_m#{version.after_comma}d#{version.before_comma.no_dots}.tgz"
 
     pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver10#{version.after_comma}.pkg"
@@ -30,6 +34,7 @@ cask "roland-quad-capture-usb-driver" do
   on_big_sur :or_newer do
     version "1.5.6,11"
     sha256 "0d77926e818e1da93ea2f980ef29d840015f085ec134a68a2501b1ccfd5ddfde"
+
     url "https://static.roland.com/assets/media/tgz/quad_mac#{version.after_comma}drv#{version.before_comma.no_dots}.tgz"
 
     pkg "QuadCaptureUSBDriver/QuadCapture_USBDriver#{version.after_comma}.pkg"

--- a/Casks/sound-blaster-play3.rb
+++ b/Casks/sound-blaster-play3.rb
@@ -5,6 +5,7 @@ cask "sound-blaster-play3" do
     sha256 "0550328b70fc214fcffc418fba3e5140c853e827bc92227a73864d62ba5e8415"
 
     url "https://files.creative.com/manualdn/Drivers/AVP/13795/0x3F213863/SBP3_MAC_L13_#{version.dots_to_underscores}.dmg.zip"
+
     pkg "Install.pkg"
 
     livecheck do
@@ -20,6 +21,7 @@ cask "sound-blaster-play3" do
     sha256 "3dbbdc627f5ee72f87403dc471e6718c258594e0fb0b208d900a5f174ce02915"
 
     url "https://files.creative.com/manualdn/Drivers/100289/MqrOwTo9a7/SBP3_MAC_L13_#{version.dots_to_underscores}.dmg"
+
     pkg "INSTALL.pkg"
 
     livecheck do


### PR DESCRIPTION
Companion PR to https://github.com/Homebrew/brew/pull/15211.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
