### PR TITLE
roli-connect: update livecheck

### DIFF
--- a/Casks/roli-connect.rb
+++ b/Casks/roli-connect.rb
@@ -9,6 +9,7 @@ cask "roli-connect" do
 
   livecheck do
     url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/}i)
     strategy :header_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-drivers/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `roli-connect` uses the `HeaderMatch` strategy, which identifies versions from response `location` headers in this case.

However, this only works as expected part of the time. The `location` URL contains lengthy query string parameters and sometimes this text is naively matched as a version, so we periodically end up with an incorrect version like `1`, `3`, etc. (instead of `1.2.2`).

This PR resolves the issue by adding a `regex` that will parse the version from the part of the URL like `/1.2.2/`, which may be a bit more reliable than parsing the version from the filename in this particular context (e.g., `ROLI%20Connect%20General%20Edition-1.2.2.dmg`).