### PR TITLE
re-added shureplus-motiv

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -39,6 +39,7 @@
   "saleae-logic": "homebrew/cask",
   "samsung-portable-ssd-t7": "homebrew/cask",
   "segger-jlink": "homebrew/cask",
+  "shureplus-motiv": "homebrew/cask",
   "silicon-labs-vcp-driver": "homebrew/cask",
   "sonos": "homebrew/cask",
   "sony-ps-remote-play": "homebrew/cask",


### PR DESCRIPTION
I already created an PR on homebrew/cask, but I was asked to change the `tap_migrations.json` in this repo.

Here is my initial PR on homebrew/cask: https://github.com/Homebrew/homebrew-cask/pull/146810

Here is the formula, which was removed: https://github.com/Homebrew/homebrew-cask-drivers/pull/3443/files#diff-a351b46295b697d813c883996bb61adb1450d451da091a863540780a7ab095a9